### PR TITLE
Refactor and split AKS functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Rancher aks-operator is a new service, which takes care about Azure Kubernetes S
 
 `export REPLACE_WITH_K8S_SECRETS_NAME=aks-secret`
 
-`kubectl create secret generic $REPLACE_WITH_K8S_SECRETS_NAME --from-literal=clientId=<REPLACE_WITH_CLIENTID> --from-literal=clientSecret=<REPLACE_WITH_CLIENTSECRET>`
+`kubectl create secret generic $REPLACE_WITH_K8S_SECRETS_NAME --from-literal=azurecredentialConfig-subscriptionId=<REPLACE_WITH_SUBSCRIPTIONID> --from-literal=azurecredentialConfig-clientId=<REPLACE_WITH_CLIENTID> --from-literal=azurecredentialConfig-clientSecret=<REPLACE_WITH_CLIENTSECRET>`
 
 ### 6. Start aks-operator
 

--- a/crds/aksclusterconfig.yaml
+++ b/crds/aksclusterconfig.yaml
@@ -132,9 +132,6 @@ spec:
             subnet:
               nullable: true
               type: string
-            subscriptionId:
-              nullable: true
-              type: string
             tags:
               additionalProperties:
                 nullable: true

--- a/examples/create-example.yaml
+++ b/examples/create-example.yaml
@@ -3,16 +3,14 @@ kind: AKSClusterConfig
 metadata:
   name: my-cluster
 spec:
-  displayName: "my-cluster"
   resourceLocation: "germanywestcentral"
   resourceGroup: "my-group"
   clusterName: "my-cluster"
   baseUrl: "https://management.azure.com/"
   authBaseUrl: "https://login.microsoftonline.com"
-  subscriptionId: "REPLACE_WITH_SUBCRIPTION_ID"
   tenantId: "REPLACE_WITH_TENANT_ID"
   azureCredentialSecret: "REPLACE_WITH_K8S_SECRETS_NAME"
-  kubernetesVersion: "1.18.14"
+  kubernetesVersion: "1.19.9"
   nodePools:
   - name: "masters"
     count: 1

--- a/examples/import-example.yaml
+++ b/examples/import-example.yaml
@@ -3,9 +3,8 @@ kind: AKSClusterConfig
 metadata:
   name: my-import-cluster
 spec:
-  displayName: my-import-cluster
-  subscriptionId: "REPLACE_WITH_SUBCRIPTION_ID"
-  azureCredentialSecret: "REPLACE_WITH_K8S_SECRETS_NAME"
+  clusterName: my-import-cluster
   tenantId: "REPLACE_WITH_TENANT_ID"
+  azureCredentialSecret: "REPLACE_WITH_K8S_SECRETS_NAME"
   imported: true
 status: {}

--- a/internal/aks/client.go
+++ b/internal/aks/client.go
@@ -1,0 +1,120 @@
+package aks
+
+import (
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-11-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-10-01/resources"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/rancher/aks-operator/internal/utils"
+	aksv1 "github.com/rancher/aks-operator/pkg/apis/aks.cattle.io/v1"
+	wranglerv1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+)
+
+type Credentials struct {
+	AuthBaseURL    *string
+	BaseURL        *string
+	SubscriptionID string
+	TenantID       string
+	ClientID       string
+	ClientSecret   string
+}
+
+func NewResourceGroupClient(cred *Credentials) (*resources.GroupsClient, error) {
+	authorizer, err := NewClientAuthorizer(cred)
+	if err != nil {
+		return nil, err
+	}
+
+	client := resources.NewGroupsClientWithBaseURI(to.String(cred.BaseURL), cred.SubscriptionID)
+	client.Authorizer = authorizer
+
+	return &client, nil
+}
+
+func NewClusterClient(cred *Credentials) (*containerservice.ManagedClustersClient, error) {
+	authorizer, err := NewClientAuthorizer(cred)
+	if err != nil {
+		return nil, err
+	}
+
+	client := containerservice.NewManagedClustersClientWithBaseURI(to.String(cred.BaseURL), cred.SubscriptionID)
+	client.Authorizer = authorizer
+
+	return &client, nil
+}
+
+func NewAgentPoolClient(cred *Credentials) (*containerservice.AgentPoolsClient, error) {
+	authorizer, err := NewClientAuthorizer(cred)
+	if err != nil {
+		return nil, err
+	}
+
+	agentProfile := containerservice.NewAgentPoolsClientWithBaseURI(to.String(cred.BaseURL), cred.SubscriptionID)
+	agentProfile.Authorizer = authorizer
+
+	return &agentProfile, nil
+}
+
+func NewClientAuthorizer(cred *Credentials) (autorest.Authorizer, error) {
+	if cred.AuthBaseURL == nil {
+		cred.AuthBaseURL = to.StringPtr(azure.PublicCloud.ActiveDirectoryEndpoint)
+	}
+
+	if cred.BaseURL == nil {
+		cred.BaseURL = to.StringPtr(azure.PublicCloud.ResourceManagerEndpoint)
+	}
+
+	oauthConfig, err := adal.NewOAuthConfig(to.String(cred.AuthBaseURL), cred.TenantID)
+	if err != nil {
+		return nil, err
+	}
+
+	spToken, err := adal.NewServicePrincipalToken(*oauthConfig, cred.ClientID, cred.ClientSecret, to.String(cred.BaseURL))
+	if err != nil {
+		return nil, fmt.Errorf("couldn't authenticate to Azure cloud with error: %v", err)
+	}
+
+	return autorest.NewBearerAuthorizer(spToken), nil
+}
+
+func GetSecrets(secretsCache wranglerv1.SecretCache, spec *aksv1.AKSClusterConfigSpec) (*Credentials, error) {
+	var cred Credentials
+
+	if spec.AzureCredentialSecret == "" {
+		return nil, fmt.Errorf("secret name not provided")
+	}
+
+	ns, id := utils.ParseSecretName(spec.AzureCredentialSecret)
+	secret, err := secretsCache.Get(ns, id)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't find secret [%s] in namespace [%s]", id, ns)
+	}
+
+	subscriptionIDBytes := secret.Data["azurecredentialConfig-subscriptionId"]
+	clientIDBytes := secret.Data["azurecredentialConfig-clientId"]
+	clientSecretBytes := secret.Data["azurecredentialConfig-clientSecret"]
+
+	cannotBeNilError := "field [azurecredentialConfig-%s] must be provided in cloud credential"
+	if subscriptionIDBytes == nil {
+		return nil, fmt.Errorf(cannotBeNilError, "subscriptionId")
+	}
+	if clientIDBytes == nil {
+		return nil, fmt.Errorf(cannotBeNilError, "clientId")
+	}
+	if clientSecretBytes == nil {
+		return nil, fmt.Errorf(cannotBeNilError, "clientSecret")
+	}
+
+	cred.SubscriptionID = string(subscriptionIDBytes)
+	cred.ClientID = string(clientIDBytes)
+	cred.ClientSecret = string(clientSecretBytes)
+	cred.TenantID = spec.TenantID
+	cred.AuthBaseURL = spec.AuthBaseURL
+	cred.BaseURL = spec.BaseURL
+
+	return &cred, nil
+}

--- a/internal/aks/create.go
+++ b/internal/aks/create.go
@@ -1,0 +1,185 @@
+package aks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-11-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-10-01/resources"
+	"github.com/Azure/go-autorest/autorest/to"
+	aksv1 "github.com/rancher/aks-operator/pkg/apis/aks.cattle.io/v1"
+)
+
+func CreateResourceGroup(ctx context.Context, groupsClient *resources.GroupsClient, spec *aksv1.AKSClusterConfigSpec) error {
+	_, err := groupsClient.CreateOrUpdate(
+		ctx,
+		spec.ResourceGroup,
+		resources.Group{
+			Name:     to.StringPtr(spec.ResourceGroup),
+			Location: to.StringPtr(spec.ResourceLocation),
+		})
+
+	return err
+}
+
+// CreateOrUpdateCluster creates a new managed Kubernetes cluster
+func CreateOrUpdateCluster(ctx context.Context, cred *Credentials, clusterClient *containerservice.ManagedClustersClient, spec *aksv1.AKSClusterConfigSpec) error {
+	dnsPrefix := spec.DNSPrefix
+	if dnsPrefix == nil {
+		dnsPrefix = to.StringPtr(spec.ClusterName)
+	}
+
+	tags := make(map[string]*string)
+	for key, val := range spec.Tags {
+		if val != "" {
+			tags[key] = to.StringPtr(val)
+		}
+	}
+
+	var vmNetSubnetID *string
+	networkProfile := &containerservice.NetworkProfile{}
+	if hasCustomVirtualNetwork(spec) {
+		virtualNetworkResourceGroup := spec.ResourceGroup
+
+		//if virtual network resource group is set, use it, otherwise assume it is the same as the cluster
+		if spec.VirtualNetworkResourceGroup != nil {
+			virtualNetworkResourceGroup = *spec.VirtualNetworkResourceGroup
+		}
+
+		vmNetSubnetID = to.StringPtr(fmt.Sprintf(
+			"/subscriptions/%v/resourceGroups/%v/providers/Microsoft.Network/virtualNetworks/%v/subnets/%v",
+			cred.SubscriptionID,
+			virtualNetworkResourceGroup,
+			spec.VirtualNetwork,
+			spec.Subnet,
+		))
+
+		networkProfile.DNSServiceIP = spec.NetworkDNSServiceIP
+		networkProfile.DockerBridgeCidr = spec.NetworkDockerBridgeCIDR
+		networkProfile.ServiceCidr = spec.NetworkServiceCIDR
+
+		if spec.NetworkPlugin != nil {
+			networkProfile.NetworkPlugin = containerservice.NetworkPlugin(*spec.NetworkPlugin)
+		} else {
+			networkProfile.NetworkPlugin = containerservice.Kubenet
+		}
+
+		// if network plugin is 'Azure', set PodCIDR
+		if networkProfile.NetworkPlugin == containerservice.Azure {
+			networkProfile.PodCidr = spec.NetworkPodCIDR
+		}
+
+		if spec.LoadBalancerSKU != nil {
+			loadBalancerSku := containerservice.LoadBalancerSku(*spec.LoadBalancerSKU)
+			networkProfile.LoadBalancerSku = loadBalancerSku
+		}
+
+		if spec.NetworkPolicy != nil {
+			networkProfile.NetworkPolicy = containerservice.NetworkPolicy(*spec.NetworkPolicy)
+		}
+	}
+
+	agentPoolProfiles := make([]containerservice.ManagedClusterAgentPoolProfile, 0, len(spec.NodePools))
+	for _, np := range spec.NodePools {
+		if np.OrchestratorVersion == nil {
+			np.OrchestratorVersion = spec.KubernetesVersion
+		}
+		agentProfile := containerservice.ManagedClusterAgentPoolProfile{
+			Name:                np.Name,
+			Count:               np.Count,
+			MaxPods:             np.MaxPods,
+			OsDiskSizeGB:        np.OsDiskSizeGB,
+			OsType:              containerservice.OSType(np.OsType),
+			VMSize:              containerservice.VMSizeTypes(np.VMSize),
+			Mode:                containerservice.AgentPoolMode(np.Mode),
+			OrchestratorVersion: np.OrchestratorVersion,
+			AvailabilityZones:   np.AvailabilityZones,
+		}
+		if np.EnableAutoScaling != nil && *np.EnableAutoScaling {
+			agentProfile.EnableAutoScaling = np.EnableAutoScaling
+			agentProfile.MaxCount = np.MaxCount
+			agentProfile.MinCount = np.MinCount
+		}
+		if hasCustomVirtualNetwork(spec) {
+			agentProfile.VnetSubnetID = vmNetSubnetID
+		}
+		agentPoolProfiles = append(agentPoolProfiles, agentProfile)
+	}
+
+	var linuxProfile *containerservice.LinuxProfile
+	if hasLinuxProfile(spec) {
+		linuxProfile = &containerservice.LinuxProfile{
+			AdminUsername: spec.LinuxAdminUsername,
+			SSH: &containerservice.SSHConfiguration{
+				PublicKeys: &[]containerservice.SSHPublicKey{
+					{
+						KeyData: spec.LinuxSSHPublicKey,
+					},
+				},
+			},
+		}
+	}
+
+	managedCluster := containerservice.ManagedCluster{
+		Name:     to.StringPtr(spec.ClusterName),
+		Location: to.StringPtr(spec.ResourceLocation),
+		Tags:     tags,
+		ManagedClusterProperties: &containerservice.ManagedClusterProperties{
+			KubernetesVersion: spec.KubernetesVersion,
+			DNSPrefix:         dnsPrefix,
+			AgentPoolProfiles: &agentPoolProfiles,
+			LinuxProfile:      linuxProfile,
+			NetworkProfile:    networkProfile,
+			ServicePrincipalProfile: &containerservice.ManagedClusterServicePrincipalProfile{
+				ClientID: to.StringPtr(cred.ClientID),
+				Secret:   to.StringPtr(cred.ClientSecret),
+			},
+		},
+	}
+
+	if spec.AuthorizedIPRanges != nil {
+		managedCluster.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{
+			AuthorizedIPRanges: spec.AuthorizedIPRanges,
+		}
+	}
+	if spec.PrivateCluster != nil && *spec.PrivateCluster {
+		managedCluster.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{
+			EnablePrivateCluster: spec.PrivateCluster,
+		}
+	}
+
+	_, err := clusterClient.CreateOrUpdate(
+		ctx,
+		spec.ResourceGroup,
+		spec.ClusterName,
+		managedCluster,
+	)
+
+	return err
+}
+
+func CreateOrUpdateAgentPool(ctx context.Context, agentPoolClient *containerservice.AgentPoolsClient, spec *aksv1.AKSClusterConfigSpec, np *aksv1.AKSNodePool) error {
+	agentProfile := &containerservice.ManagedClusterAgentPoolProfileProperties{
+		Count:               np.Count,
+		MaxPods:             np.MaxPods,
+		OsDiskSizeGB:        np.OsDiskSizeGB,
+		OsType:              containerservice.OSType(np.OsType),
+		VMSize:              containerservice.VMSizeTypes(np.VMSize),
+		Mode:                containerservice.AgentPoolMode(np.Mode),
+		OrchestratorVersion: np.OrchestratorVersion,
+	}
+
+	_, err := agentPoolClient.CreateOrUpdate(ctx, spec.ResourceGroup, spec.ClusterName, to.String(np.Name), containerservice.AgentPool{
+		ManagedClusterAgentPoolProfileProperties: agentProfile,
+	})
+
+	return err
+}
+
+func hasCustomVirtualNetwork(spec *aksv1.AKSClusterConfigSpec) bool {
+	return spec.VirtualNetwork != nil && spec.Subnet != nil
+}
+
+func hasLinuxProfile(spec *aksv1.AKSClusterConfigSpec) bool {
+	return spec.LinuxAdminUsername != nil && spec.LinuxSSHPublicKey != nil
+}

--- a/internal/aks/delete.go
+++ b/internal/aks/delete.go
@@ -1,0 +1,36 @@
+package aks
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-11-01/containerservice"
+	"github.com/Azure/go-autorest/autorest/to"
+	aksv1 "github.com/rancher/aks-operator/pkg/apis/aks.cattle.io/v1"
+	"github.com/sirupsen/logrus"
+)
+
+// RemoveCluster Delete AKS managed Kubernetes cluster
+func RemoveCluster(ctx context.Context, clusterClient *containerservice.ManagedClustersClient, spec *aksv1.AKSClusterConfigSpec) error {
+	future, err := clusterClient.Delete(ctx, spec.ResourceGroup, spec.ClusterName)
+	if err != nil {
+		return err
+	}
+
+	err = future.WaitForCompletionRef(ctx, clusterClient.Client)
+	if err != nil {
+		logrus.Errorf("can't get the AKS cluster create or update future response: %v", err)
+		return err
+	}
+
+	logrus.Infof("Cluster %v removed successfully", spec.ClusterName)
+	logrus.Debugf("Cluster removal status %v", future.Status())
+
+	return nil
+}
+
+// RemoveAgentPool Delete AKS Agent Pool
+func RemoveAgentPool(ctx context.Context, agentPoolClient *containerservice.AgentPoolsClient, spec *aksv1.AKSClusterConfigSpec, np *aksv1.AKSNodePool) error {
+	_, err := agentPoolClient.Delete(ctx, spec.ResourceGroup, spec.ClusterName, to.String(np.Name))
+
+	return err
+}

--- a/internal/aks/exists.go
+++ b/internal/aks/exists.go
@@ -1,0 +1,22 @@
+package aks
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-11-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-10-01/resources"
+	aksv1 "github.com/rancher/aks-operator/pkg/apis/aks.cattle.io/v1"
+)
+
+func ExistsResourceGroup(ctx context.Context, groupsClient *resources.GroupsClient, resourceGroup string) bool {
+	resp, err := groupsClient.CheckExistence(ctx, resourceGroup)
+
+	return err == nil && resp.StatusCode == 204
+}
+
+// ExistsCluster Check if AKS managed Kubernetes cluster exist
+func ExistsCluster(ctx context.Context, clusterClient *containerservice.ManagedClustersClient, spec *aksv1.AKSClusterConfigSpec) bool {
+	resp, err := clusterClient.Get(ctx, spec.ResourceGroup, spec.ClusterName)
+
+	return err == nil && resp.StatusCode == 200
+}

--- a/internal/utils/map.go
+++ b/internal/utils/map.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"fmt"
+
+	aksv1 "github.com/rancher/aks-operator/pkg/apis/aks.cattle.io/v1"
+)
+
+func BuildNodePoolMap(nodePools []aksv1.AKSNodePool, clusterName string) (map[string]*aksv1.AKSNodePool, error) {
+	ret := make(map[string]*aksv1.AKSNodePool, len(nodePools))
+	for i := range nodePools {
+		if nodePools[i].Name != nil {
+			if _, ok := ret[*nodePools[i].Name]; ok {
+				return nil, fmt.Errorf("cluster [%s] cannot have multiple nodepools with name %s", clusterName, *nodePools[i].Name)
+			}
+			ret[*nodePools[i].Name] = &nodePools[i]
+		}
+	}
+	return ret, nil
+}

--- a/internal/utils/parse.go
+++ b/internal/utils/parse.go
@@ -1,4 +1,4 @@
-package controller
+package utils
 
 import (
 	"strings"

--- a/pkg/apis/aks.cattle.io/v1/types.go
+++ b/pkg/apis/aks.cattle.io/v1/types.go
@@ -37,7 +37,6 @@ type AKSClusterConfigSpec struct {
 	ResourceLocation            string            `json:"resourceLocation" norman:"noupdate"`
 	ResourceGroup               string            `json:"resourceGroup" norman:"noupdate"`
 	ClusterName                 string            `json:"clusterName" norman:"noupdate"`
-	SubscriptionID              string            `json:"subscriptionId"`
 	TenantID                    string            `json:"tenantId"`
 	AzureCredentialSecret       string            `json:"azureCredentialSecret"`
 	BaseURL                     *string           `json:"baseUrl"`


### PR DESCRIPTION
* Split AKS specific functions into new package module
* Refactor aks-operator controller
  - Add more options to be updated by updateUpstreamClusterState
  - Move validation function for orchestration version to UI proxy
  - Stop removing Resource Group after cluster removal
