### PR TITLE
Add HTTP Application Routing

### DIFF
--- a/charts/aks-operator-crd/templates/crds.yaml
+++ b/charts/aks-operator-crd/templates/crds.yaml
@@ -46,6 +46,9 @@ spec:
             dockerBridgeCidr:
               nullable: true
               type: string
+            httpApplicationRouting:
+              nullable: true
+              type: boolean
             imported:
               type: boolean
             kubernetesVersion:

--- a/controller/aks-cluster-config-handler.go
+++ b/controller/aks-cluster-config-handler.go
@@ -581,6 +581,12 @@ func BuildUpstreamClusterState(ctx context.Context, secretsCache wranglerv1.Secr
 		upstreamSpec.LinuxSSHPublicKey = sshKeys[0].KeyData
 	}
 
+	// set addons profile
+	addonProfile := clusterState.AddonProfiles
+	if addonProfile != nil && addonProfile["httpApplicationRouting"] != nil {
+		upstreamSpec.HTTPApplicationRouting = addonProfile["httpApplicationRouting"].Enabled
+	}
+
 	// set API server access profile
 	upstreamSpec.PrivateCluster = to.BoolPtr(false)
 	if clusterState.APIServerAccessProfile != nil {
@@ -597,7 +603,8 @@ func BuildUpstreamClusterState(ctx context.Context, secretsCache wranglerv1.Secr
 
 // updateUpstreamClusterState compares the upstream spec with the config spec, then updates the upstream AKS cluster to
 // match the config spec. Function returns after a update is finished.
-func (h *Handler) updateUpstreamClusterState(ctx context.Context, secretsCache wranglerv1.SecretCache, config *aksv1.AKSClusterConfig, upstreamSpec *aksv1.AKSClusterConfigSpec) (*aksv1.AKSClusterConfig, error) {
+func (h *Handler) updateUpstreamClusterState(ctx context.Context, secretsCache wranglerv1.SecretCache,
+	config *aksv1.AKSClusterConfig, upstreamSpec *aksv1.AKSClusterConfigSpec) (*aksv1.AKSClusterConfig, error) {
 	credentials, err := aks.GetSecrets(secretsCache, &config.Spec)
 	if err != nil {
 		return config, err
@@ -697,6 +704,14 @@ func (h *Handler) updateUpstreamClusterState(ctx context.Context, secretsCache w
 		}
 	}
 
+	// check addon HTTP Application Routing
+	if config.Spec.HTTPApplicationRouting != nil {
+		if to.Bool(config.Spec.HTTPApplicationRouting) != to.Bool(upstreamSpec.HTTPApplicationRouting) {
+			logrus.Infof("Updating HTTP application routing for cluster [%s]", config.Spec.ClusterName)
+			updateAksCluster = true
+		}
+	}
+
 	if updateAksCluster {
 		resourceGroupsClient, err := aks.NewResourceGroupClient(credentials)
 		if err != nil {
@@ -705,7 +720,7 @@ func (h *Handler) updateUpstreamClusterState(ctx context.Context, secretsCache w
 
 		if !aks.ExistsResourceGroup(ctx, resourceGroupsClient, config.Spec.ResourceGroup) {
 			logrus.Infof("Resource group [%s] does not exist, creating", config.Spec.ResourceGroup)
-			if err := aks.CreateResourceGroup(ctx, resourceGroupsClient, &config.Spec); err != nil {
+			if err = aks.CreateResourceGroup(ctx, resourceGroupsClient, &config.Spec); err != nil {
 				return config, fmt.Errorf("error during updating resource group %v", err)
 			}
 			logrus.Infof("Resource group [%s] updated successfully", config.Spec.ResourceGroup)

--- a/internal/aks/client.go
+++ b/internal/aks/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-11-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/operationalinsights/mgmt/2020-08-01/operationalinsights"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-10-01/resources"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
@@ -57,6 +58,18 @@ func NewAgentPoolClient(cred *Credentials) (*containerservice.AgentPoolsClient, 
 	agentProfile.Authorizer = authorizer
 
 	return &agentProfile, nil
+}
+
+func NewOperationInsightsWorkspaceClient(cred *Credentials) (*operationalinsights.WorkspacesClient, error) {
+	authorizer, err := NewClientAuthorizer(cred)
+	if err != nil {
+		return nil, err
+	}
+
+	client := operationalinsights.NewWorkspacesClientWithBaseURI(to.String(cred.BaseURL), cred.SubscriptionID)
+	client.Authorizer = authorizer
+
+	return &client, nil
 }
 
 func NewClientAuthorizer(cred *Credentials) (autorest.Authorizer, error) {

--- a/pkg/apis/aks.cattle.io/v1/types.go
+++ b/pkg/apis/aks.cattle.io/v1/types.go
@@ -58,6 +58,7 @@ type AKSClusterConfigSpec struct {
 	NodePools                   []AKSNodePool     `json:"nodePools"`
 	PrivateCluster              *bool             `json:"privateCluster"`
 	AuthorizedIPRanges          *[]string         `json:"authorizedIpRanges"`
+	HTTPApplicationRouting      *bool             `json:"httpApplicationRouting"`
 }
 
 type AKSClusterConfigStatus struct {

--- a/pkg/apis/aks.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/aks.cattle.io/v1/zz_generated_deepcopy.go
@@ -196,6 +196,11 @@ func (in *AKSClusterConfigSpec) DeepCopyInto(out *AKSClusterConfigSpec) {
 			copy(*out, *in)
 		}
 	}
+	if in.HTTPApplicationRouting != nil {
+		in, out := &in.HTTPApplicationRouting, &out.HTTPApplicationRouting
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Add new option to addon profile HTTPApplicationRouting which
configures an Ingress controller in AKS cluster.

Issue: https://github.com/rancher/rancher/issues/32674