### PR TITLE
Fix autoscaling for nodedools

### DIFF
--- a/internal/aks/create.go
+++ b/internal/aks/create.go
@@ -178,7 +178,11 @@ func CreateOrUpdateAgentPool(ctx context.Context, agentPoolClient *containerserv
 		OsType:              containerservice.OSType(np.OsType),
 		VMSize:              containerservice.VMSizeTypes(np.VMSize),
 		Mode:                containerservice.AgentPoolMode(np.Mode),
+		Type:                containerservice.VirtualMachineScaleSets,
 		OrchestratorVersion: np.OrchestratorVersion,
+		EnableAutoScaling:   np.EnableAutoScaling,
+		MinCount:            np.MinCount,
+		MaxCount:            np.MaxCount,
 	}
 
 	_, err := agentPoolClient.CreateOrUpdate(ctx, spec.ResourceGroup, spec.ClusterName, to.String(np.Name), containerservice.AgentPool{


### PR DESCRIPTION
Fix enabling autoscaling for nodepools after AKS cluster was provisioned

Issue: https://github.com/rancher/rancher/issues/32956