### PR TITLE
Add availability zones in node pools

### DIFF
--- a/pkg/aks/create.go
+++ b/pkg/aks/create.go
@@ -209,6 +209,7 @@ func CreateOrUpdateAgentPool(ctx context.Context, agentPoolClient *containerserv
 		Mode:                containerservice.AgentPoolMode(np.Mode),
 		Type:                containerservice.VirtualMachineScaleSets,
 		OrchestratorVersion: np.OrchestratorVersion,
+		AvailabilityZones:   np.AvailabilityZones,
 		EnableAutoScaling:   np.EnableAutoScaling,
 		MinCount:            np.MinCount,
 		MaxCount:            np.MaxCount,


### PR DESCRIPTION
It was missing AvailabilityZones option in CreateOrUpdateAgentPool

Issue: https://github.com/rancher/rancher/issues/32960