### PR TITLE
Use same SLES image as Rancher

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -53,6 +53,17 @@ steps:
     event:
     - tag
 
+- name: docker-build
+  image: plugins/docker
+  settings:
+    dockerfile: package/Dockerfile
+    repo: "rancher/aks-operator"
+    tag: "${DRONE_COMMIT}-amd64"
+    dry_run: true
+  when:
+    event:
+      - pull_request
+
 volumes:
 - name: docker
   host:
@@ -113,6 +124,17 @@ steps:
   when:
     event:
     - tag
+
+- name: docker-build
+  image: plugins/docker
+  settings:
+    dockerfile: package/Dockerfile
+    repo: "rancher/aks-operator"
+    tag: "${DRONE_COMMIT}-arm64"
+    dry_run: true
+  when:
+    event:
+      - pull_request
 
 volumes:
 - name: docker

--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,12 +1,21 @@
-FROM golang:1.16
+FROM registry.suse.com/suse/sle15:15.3
 
 ARG DAPPER_HOST_ARCH
-ENV ARCH $DAPPER_HOST_ARCH
+ENV ARCH=${DAPPER_HOST_ARCH}
 
-RUN apt update && \
-    apt install -y bash git gcc docker.io vim less file curl wget ca-certificates
+RUN zypper -n update && \
+    zypper -n install bash git binutils glibc-devel-static gcc vim less file tar gzip curl sed wget ca-certificates
+
+ENV GOLANG_ARCH_amd64=amd64 GOLANG_ARCH_arm=armv6l GOLANG_ARCH_arm64=arm64 GOLANG_ARCH=GOLANG_ARCH_${ARCH} \
+    GOPATH=/go PATH=/go/bin:/usr/local/go/bin:${PATH} SHELL=/bin/bash
+RUN curl -sLf https://storage.googleapis.com/golang/go1.16.4.linux-${ARCH}.tar.gz | tar -xzf - -C /usr/local/
+# workaround for https://bugzilla.suse.com/show_bug.cgi?id=1183043
+RUN if [ "${ARCH}" == "arm64" ]; then \
+        zypper -n install binutils-gold ; \
+    fi
+
 RUN if [ "${ARCH}" = "amd64" ]; then \
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0; \
+        curl -sL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.40.1; \
     fi
 RUN curl -sL https://get.helm.sh/helm-v3.3.0-linux-${ARCH}.tar.gz | tar xvzf - -C /usr/local/bin --strip-components=1
 

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,8 +1,9 @@
-ARG UBI_IMAGE=registry.access.redhat.com/ubi8/ubi-minimal:latest
-FROM ${UBI_IMAGE}
-ENV KUBECONFIG /root/.kube/config
-RUN microdnf update -y && \
-    rm -rf /var/cache/yum
+FROM registry.suse.com/suse/sle15:15.3
+RUN zypper update -y && \
+    zypper -n clean -a && \
+    rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*
+RUN useradd --uid 1007 aks-operator
+ENV KUBECONFIG /home/aks-operator/.kube/config
 COPY bin/aks-operator /usr/bin/
-USER 1001
+USER 1007
 ENTRYPOINT ["aks-operator"]

--- a/scripts/package
+++ b/scripts/package
@@ -5,21 +5,6 @@ source $(dirname $0)/version
 
 cd $(dirname $0)/..
 
-function build-image() {
-  IMAGE=${REPO}/${1}:${TAG}
-  DOCKERFILE=package/Dockerfile${2}
-  if [ -e ${DOCKERFILE}.${ARCH} ]; then
-      DOCKERFILE=${DOCKERFILE}.${ARCH}
-  fi
-
-  docker build -f ${DOCKERFILE} -t ${IMAGE} .
-  echo Built ${IMAGE}
-
-  if [ "$PUSH" = "true" ]; then
-      docker push ${IMAGE}
-  fi
-}
-
 mkdir -p dist/artifacts
 cp bin/aks-operator dist/artifacts/aks-operator-linux${SUFFIX}
 for i in bin/aks-operator-*; do
@@ -27,7 +12,5 @@ for i in bin/aks-operator-*; do
           cp $i dist/artifacts
     fi
 done
-
-build-image aks-operator
 
 ./scripts/package-helm


### PR DESCRIPTION
In addition to using the SLES image for the aks-operator image, the
dapper image is also switched to using SLES.
    
A side effect of this is that docker will no longer be installed in the
dapper image. Instead, a new pipeline step is added to build the image
on pull requests.