### PR TITLE
Don't attempt to update immutable properties

### DIFF
--- a/controller/aks-cluster-config-handler.go
+++ b/controller/aks-cluster-config-handler.go
@@ -237,7 +237,7 @@ func (h *Handler) createCluster(config *aksv1.AKSClusterConfig) (*aksv1.AKSClust
 		return config, err
 	}
 
-	err = aks.CreateOrUpdateCluster(ctx, credentials, resourceClusterClient, &config.Spec)
+	err = aks.CreateOrUpdateCluster(ctx, credentials, resourceClusterClient, &config.Spec, config.Status.Phase)
 	if err != nil {
 		return config, fmt.Errorf("error failed to create cluster: %v ", err)
 	}
@@ -370,6 +370,9 @@ func (h *Handler) validateConfig(config *aksv1.AKSClusterConfig) error {
 	}
 	if config.Spec.KubernetesVersion == nil {
 		return fmt.Errorf(cannotBeNilError, "kubernetesVersion", config.ClusterName)
+	}
+	if config.Spec.DNSPrefix == nil {
+		return fmt.Errorf(cannotBeNilError, "dnsPrefix", config.ClusterName)
 	}
 
 	systemMode := false
@@ -810,7 +813,7 @@ func (h *Handler) updateUpstreamClusterState(ctx context.Context, secretsCache w
 			logrus.Infof("Resource group [%s] updated successfully", config.Spec.ResourceGroup)
 		}
 
-		err = aks.CreateOrUpdateCluster(ctx, credentials, resourceClusterClient, &config.Spec)
+		err = aks.CreateOrUpdateCluster(ctx, credentials, resourceClusterClient, &config.Spec, config.Status.Phase)
 		if err != nil {
 			return config, fmt.Errorf("failed to update cluster: %v", err)
 		}


### PR DESCRIPTION
Without this change, setting ServicePrincipalProfile on a cluster update
causes an error: "Changing property 'servicePrincipalProfile.clientId'
is not allowed", even though the clientID is not different. This change
checks whether the cluster is in an updating state before trying to set
the ServicePrincipalProfile on the cluster object.

Additionally, since DNSPrefix is nil for imported clusters, this value
was being changed to the cluster name, which might not be the true
value, and so was causing the operator to try to change it even though
it is immutable. This change makes it a required property, which is
already the case in UI, and ignores it if it is nil which will be the
case for imported clusters.

https://github.com/rancher/rancher/issues/33536