### PR TITLE
fixed addon profiles overwriting each other

### DIFF
--- a/controller/aks-cluster-config-handler.go
+++ b/controller/aks-cluster-config-handler.go
@@ -50,8 +50,8 @@ const (
 	// node software, return code 3
 	ClusterStatusInProgress = "InProgress"
 
-	// ClusterStatusUpgrading The Upgrading state indicates the cluster is updating
-	ClusterStatusUpgrading = "Upgrading"
+	// ClusterStatusUpdating The Updating state indicates the cluster is updating
+	ClusterStatusUpdating = "Updating"
 
 	// ClusterStatusCanceled The Canceled state indicates that create or update was canceled, return code 2
 	ClusterStatusCanceled = "Canceled"
@@ -297,7 +297,7 @@ func (h *Handler) checkAndUpdate(config *aksv1.AKSClusterConfig) (*aksv1.AKSClus
 	if clusterState == ClusterStatusFailed {
 		return config, fmt.Errorf("update failed for cluster [%s], status: %s", config.Spec.ClusterName, clusterState)
 	}
-	if clusterState == ClusterStatusInProgress || clusterState == ClusterStatusUpgrading {
+	if clusterState == ClusterStatusInProgress || clusterState == ClusterStatusUpdating {
 		// If the cluster is in an active state in Rancher but is updating in AKS, then an update was initiated outside of Rancher,
 		// such as in AKS console. In this case, this is a no-op and the reconciliation will happen after syncing.
 		if config.Status.Phase == aksConfigActivePhase {

--- a/pkg/aks/create.go
+++ b/pkg/aks/create.go
@@ -110,21 +110,17 @@ func CreateOrUpdateCluster(ctx context.Context, cred *Credentials, clusterClient
 		}
 	}
 
-	var addonProfiles map[string]*containerservice.ManagedClusterAddonProfile
+	addonProfiles := make(map[string]*containerservice.ManagedClusterAddonProfile, 0)
 
 	if hasHTTPApplicationRoutingSupport(spec) {
-		addonProfiles = map[string]*containerservice.ManagedClusterAddonProfile{
-			"httpApplicationRouting": {
-				Enabled: spec.HTTPApplicationRouting,
-			},
+		addonProfiles["httpApplicationRouting"] = &containerservice.ManagedClusterAddonProfile{
+			Enabled: spec.HTTPApplicationRouting,
 		}
 	}
 
 	if to.Bool(spec.Monitoring) {
-		addonProfiles = map[string]*containerservice.ManagedClusterAddonProfile{
-			"omsAgent": {
-				Enabled: spec.Monitoring,
-			},
+		addonProfiles["omsAgent"] = &containerservice.ManagedClusterAddonProfile{
+			Enabled: spec.Monitoring,
 		}
 
 		operationInsightsWorkspaceClient, err := NewOperationInsightsWorkspaceClient(cred)


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/34244

# PROBLEM
If you enable container monitoring, httpApplicationRouting would never turn on.

# SOLUTION
The addonProfiles were being overwritten instead of appended too.  This caused the operator to continue updating the cluster infinitely.  I fixed this logic so that an combination of monitoring and http application routing can be configured.  I also fixed the operator attempting to update the cluster when it was already in an updating state.