### PR TITLE
Remove incorrect norman:pointer tags from AKS operator

### DIFF
--- a/pkg/apis/aks.cattle.io/v1/types.go
+++ b/pkg/apis/aks.cattle.io/v1/types.go
@@ -54,8 +54,8 @@ type AKSClusterConfigSpec struct {
 	LinuxSSHPublicKey           *string           `json:"sshPublicKey,omitempty" norman:"pointer"`
 	DNSPrefix                   *string           `json:"dnsPrefix,omitempty" norman:"pointer"`
 	KubernetesVersion           *string           `json:"kubernetesVersion" norman:"pointer"`
-	Tags                        map[string]string `json:"tags" norman:"pointer"`
-	NodePools                   []AKSNodePool     `json:"nodePools" norman:"pointer"`
+	Tags                        map[string]string `json:"tags"`
+	NodePools                   []AKSNodePool     `json:"nodePools"`
 	PrivateCluster              *bool             `json:"privateCluster"`
 	AuthorizedIPRanges          *[]string         `json:"authorizedIpRanges" norman:"pointer"`
 	HTTPApplicationRouting      *bool             `json:"httpApplicationRouting"`


### PR DESCRIPTION
Address https://github.com/rancher/rancher/issues/36128.

A KEv2 cluster imported with the rancher2 terraform provider will currently delete all node groups on import if no node groups are specified in the terraform config.

This is happening because the NodeGroups cluster config field (and all slices and maps) in the KEv2 operators have the norman:pointer tag. The problem is that the norman:pointer tag is added to fields that are already pointers. When node groups is not specified in the terraform config, terraform sets the node group field in the management cluster yaml as an empty array instead of null. If node groups is an empty array, Rancher deletes all node groups from the imported cluster because that is the template given: no node groups. Removing the incorrect tag will make node groups null and Rancher will take no action against imported clusters.

This fix is being made in the EKS, AKS, and GKE operators so node groups will never get deleted when a user tries to import a cluster with terraform.