### PR TITLE
Add checks for misconfigured oms agent

### DIFF
--- a/controller/aks-cluster-config-handler.go
+++ b/controller/aks-cluster-config-handler.go
@@ -665,6 +665,10 @@ func BuildUpstreamClusterState(ctx context.Context, secretsCache wranglerv1.Secr
 	// set addon monitoring profile
 	if addonProfile["omsAgent"] != nil {
 		upstreamSpec.Monitoring = addonProfile["omsAgent"].Enabled
+
+		if len(addonProfile["omsAgent"].Config) == 0 {
+			return nil, fmt.Errorf("cannot set OMS Agent configuration retrieved from Azure")
+		}
 		logAnalyticsWorkspaceResourceID := addonProfile["omsAgent"].Config["logAnalyticsWorkspaceResourceID"]
 
 		logAnalyticsWorkspaceGroup := matchWorkspaceGroup.FindStringSubmatch(to.String(logAnalyticsWorkspaceResourceID))[1]


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36425 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
 
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable.  If this is a new feature describe why we need this feature and how it will be used. -->
 
The customer had an Azure setup where they had log analytics enabled on an AKS cluster, but either didn't have the OMS agent configured or it was misconfigured. This caused a panic in Rancher. I reproduced the issue internally, and fixed it by adding checks for a nil or empty OMS agent profile configuration.

## Solution
 
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 
## Testing
 
<!-- Describe what, if any, testing you did.  If you added tests describe what cases they cover and do not cover. -->

1. Added test code to a local copy of `rancher/aks-operator` simulating a nil or misconfigured OMS agent profile in an Azure portal setup
2. Ran standalone `ask-operator`
3. Ran an instance of Rancher v2.6-head and scaled the ask-operator deployment count to 0
4. Created an AKS cluster through Rancher
5. Checked that an invalid oms agent configuration error is seen in the UI

![image](https://user-images.githubusercontent.com/12955547/155425714-aec97506-60f9-4738-9cf6-e820541822fe.png)

![image](https://user-images.githubusercontent.com/12955547/155425730-5013846f-58e2-42de-9d9b-c80678831970.png)