### PR TITLE
[2.6.5] Fix basic AKS load balancer

### DIFF
--- a/pkg/aks/create.go
+++ b/pkg/aks/create.go
@@ -83,8 +83,12 @@ func CreateOrUpdateCluster(ctx context.Context, cred *Credentials, clusterClient
 			VMSize:              containerservice.VMSizeTypes(np.VMSize),
 			Mode:                containerservice.AgentPoolMode(np.Mode),
 			OrchestratorVersion: np.OrchestratorVersion,
-			AvailabilityZones:   np.AvailabilityZones,
 		}
+
+		if np.AvailabilityZones != nil && len(*np.AvailabilityZones) > 0 {
+			agentProfile.AvailabilityZones = np.AvailabilityZones
+		}
+
 		if np.EnableAutoScaling != nil && *np.EnableAutoScaling {
 			agentProfile.EnableAutoScaling = np.EnableAutoScaling
 			agentProfile.MaxCount = np.MaxCount


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/36959

Problem
Users were unable to provision AKS clusters using a basic load balancer. When creating an AKS cluster with a basic load balancer, Rancher was setting the node pool AvailabilityZones field to an empty list (as availability zones cannot be used with a basic load balancer). However, this caused Azure to mistakenly believe that we had provided some availability zones, preventing the use of a basic load balancer.

Solution
This problem has been resolved by ensuring that any empty AvailabilityZones slices are set to nil.

Testing
I've created several AKS clusters using a basic load balancer and they have provisioned correctly and transitioned into an active state without error. Cluster state syncing also persists the `nil` availability zones. 

###### thanks @thedadams for helping point me in the right direction with this one!