### PR TITLE
Add duplicate cluster check

### DIFF
--- a/controller/aks-cluster-config-handler.go
+++ b/controller/aks-cluster-config-handler.go
@@ -221,6 +221,17 @@ func (h *Handler) createCluster(config *aksv1.AKSClusterConfig) (*aksv1.AKSClust
 		return config, err
 	}
 
+	resourceClusterClient, err := aks.NewClusterClient(credentials)
+	if err != nil {
+		return config, err
+	}
+
+	logrus.Infof("Checking if cluster [%s] exists", config.Spec.ClusterName)
+
+	if aks.ExistsCluster(ctx, resourceClusterClient, &config.Spec) {
+		return config, fmt.Errorf("cluster [%s] already exists in AKS. Please import it", config.Spec.ClusterName)
+	}
+
 	resourceGroupsClient, err := aks.NewResourceGroupClient(credentials)
 	if err != nil {
 		return config, err
@@ -238,11 +249,6 @@ func (h *Handler) createCluster(config *aksv1.AKSClusterConfig) (*aksv1.AKSClust
 	}
 
 	logrus.Infof("Creating AKS cluster [%s]", config.Spec.ClusterName)
-
-	resourceClusterClient, err := aks.NewClusterClient(credentials)
-	if err != nil {
-		return config, err
-	}
 
 	err = aks.CreateCluster(ctx, credentials, resourceClusterClient, &config.Spec, config.Status.Phase)
 	if err != nil {

--- a/controller/aks-cluster-config-handler.go
+++ b/controller/aks-cluster-config-handler.go
@@ -153,7 +153,12 @@ func (h *Handler) OnAksConfigRemoved(key string, config *aksv1.AKSClusterConfig)
 		return config, err
 	}
 
-	if aks.ExistsCluster(ctx, resourceClusterClient, &config.Spec) {
+	clusterExists, err := aks.ExistsCluster(ctx, resourceClusterClient, &config.Spec)
+	if err != nil && strings.Contains(err.Error(), "unauthorized") {
+		logrus.Infof("user does not have permissions to access cluster [%s]: %s", config.Spec.ClusterName, err)
+	}
+
+	if clusterExists {
 		if err = aks.RemoveCluster(ctx, resourceClusterClient, &config.Spec); err != nil {
 			return config, fmt.Errorf("error removing cluster [%s] message %v", config.Spec.ClusterName, err)
 		}
@@ -228,8 +233,13 @@ func (h *Handler) createCluster(config *aksv1.AKSClusterConfig) (*aksv1.AKSClust
 
 	logrus.Infof("Checking if cluster [%s] exists", config.Spec.ClusterName)
 
-	if aks.ExistsCluster(ctx, resourceClusterClient, &config.Spec) {
-		return config, fmt.Errorf("cluster [%s] already exists in AKS. Please import it", config.Spec.ClusterName)
+	clusterExists, err := aks.ExistsCluster(ctx, resourceClusterClient, &config.Spec)
+	if err != nil && strings.Contains(err.Error(), "unauthorized") {
+		logrus.Infof("user does not have permissions to access cluster [%s]: %s", config.Spec.ClusterName, err)
+	}
+
+	if clusterExists {
+		return config, fmt.Errorf("cluster [%s] already exists in AKS. Update configuration or import the existing one", config.Spec.ClusterName)
 	}
 
 	resourceGroupsClient, err := aks.NewResourceGroupClient(credentials)
@@ -239,7 +249,12 @@ func (h *Handler) createCluster(config *aksv1.AKSClusterConfig) (*aksv1.AKSClust
 
 	logrus.Infof("Checking if resource group [%s] exists", config.Spec.ResourceGroup)
 
-	if !aks.ExistsResourceGroup(ctx, resourceGroupsClient, config.Spec.ResourceGroup) {
+	resourceGroupExists, err := aks.ExistsResourceGroup(ctx, resourceGroupsClient, config.Spec.ResourceGroup)
+	if err != nil && strings.Contains(err.Error(), "unauthorized") {
+		logrus.Infof("user does not have permissions to access resource group [%s]: %s", config.Spec.ResourceGroup, err)
+	}
+
+	if !resourceGroupExists {
 		logrus.Infof("Creating resource group [%s] for cluster [%s]", config.Spec.ResourceGroup, config.Spec.ClusterName)
 		err = aks.CreateResourceGroup(ctx, resourceGroupsClient, &config.Spec)
 		if err != nil {
@@ -791,7 +806,12 @@ func (h *Handler) updateUpstreamClusterState(ctx context.Context, secretsCache w
 			return config, err
 		}
 
-		if !aks.ExistsResourceGroup(ctx, resourceGroupsClient, config.Spec.ResourceGroup) {
+		resourceGroupExists, err := aks.ExistsResourceGroup(ctx, resourceGroupsClient, config.Spec.ResourceGroup)
+		if err != nil && strings.Contains(err.Error(), "unauthorized") {
+			logrus.Infof("user does not have permissions to access resource group [%s]: %s", config.Spec.ResourceGroup, err)
+		}
+
+		if !resourceGroupExists {
 			logrus.Infof("Resource group [%s] does not exist, creating", config.Spec.ResourceGroup)
 			if err = aks.CreateResourceGroup(ctx, resourceGroupsClient, &config.Spec); err != nil {
 				return config, fmt.Errorf("error during updating resource group %v", err)

--- a/pkg/aks/exists.go
+++ b/pkg/aks/exists.go
@@ -8,15 +8,19 @@ import (
 	aksv1 "github.com/rancher/aks-operator/pkg/apis/aks.cattle.io/v1"
 )
 
-func ExistsResourceGroup(ctx context.Context, groupsClient *resources.GroupsClient, resourceGroup string) bool {
+func ExistsResourceGroup(ctx context.Context, groupsClient *resources.GroupsClient, resourceGroup string) (bool, error) {
 	resp, err := groupsClient.CheckExistence(ctx, resourceGroup)
 
-	return err == nil && resp.StatusCode == 204
+	// client should return 204 (no content) and if not, return false and the associated error.
+	return resp.StatusCode == 204, err
 }
 
 // ExistsCluster Check if AKS managed Kubernetes cluster exist
-func ExistsCluster(ctx context.Context, clusterClient *containerservice.ManagedClustersClient, spec *aksv1.AKSClusterConfigSpec) bool {
+func ExistsCluster(ctx context.Context, clusterClient *containerservice.ManagedClustersClient, spec *aksv1.AKSClusterConfigSpec) (bool, error) {
 	resp, err := clusterClient.Get(ctx, spec.ResourceGroup, spec.ClusterName)
 
-	return err == nil && resp.StatusCode == 200
+	// client should return 200 OK and if not, return false and the associated error. If the error is non nil and
+	// permissions related, we will want that bubbled up to the ui so the user knows to adjust their resource permissions
+	// in AKS.
+	return resp.StatusCode == 200, err
 }


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/37955

## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When you try to provision an AKS cluster with the same name and resource group as one that already exists in Azure, an error appears in the rancher UI because the [CreateOrUpdate call to AKS](https://github.com/rancher/aks-operator/blob/a32c2bf0c3254301d1257345d4db786fef49162e/pkg/aks/create.go#L186) fails.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Added check for existing cluster in the aks operator `CreateCluster` function. If the cluster name in the specified resource group already exists in Azure, an error `cluster [name] already exists in Azure. Please import it` will now display in the rancher UI. This is much clearer for the customer and short circuits unnecessary API calls being made to create the managed cluster.

## Testing

Smoke test
* Create an AKS cluster in Azure Portal with [name] and [resource group]
* Create an AKS cluster in the rancher UI with [name] and [resource group]. Verify the following error thrown:

![image](https://user-images.githubusercontent.com/12955547/187775589-a66f8dcb-ea71-4804-8dad-52e86c133e80.png)

* Create an AKS cluster in the rancher UI with [name] and [resource group 2]. Verify cluster provisions successfully
* Create an AKS cluster in the rancher UI with [name2] and [resource group]. Verify cluster provisions successfully