### PR TITLE
Add checks for monitoring workspace group/name

### DIFF
--- a/controller/aks-cluster-config-handler.go
+++ b/controller/aks-cluster-config-handler.go
@@ -79,8 +79,8 @@ const (
 	NodePoolUpgrading = "Upgrading"
 )
 
-var matchWorkspaceGroup = regexp.MustCompile("/resourcegroups/(.+?)/")
-var matchWorkspaceName = regexp.MustCompile("/workspaces/(.+?)$")
+var matchWorkspaceGroup = regexp.MustCompile("/(?i)resourcegroups/(.+?)/")
+var matchWorkspaceName = regexp.MustCompile("/(?i)workspaces/(.+?)$")
 
 type Handler struct {
 	aksCC           v10.AKSClusterConfigClient
@@ -697,10 +697,18 @@ func BuildUpstreamClusterState(ctx context.Context, secretsCache wranglerv1.Secr
 		}
 		logAnalyticsWorkspaceResourceID := addonProfile["omsAgent"].Config["logAnalyticsWorkspaceResourceID"]
 
-		logAnalyticsWorkspaceGroup := matchWorkspaceGroup.FindStringSubmatch(to.String(logAnalyticsWorkspaceResourceID))[1]
+		group := matchWorkspaceGroup.FindStringSubmatch(to.String(logAnalyticsWorkspaceResourceID))
+		if group == nil {
+			return nil, fmt.Errorf("OMS Agent configuration workspace group was not found")
+		}
+		logAnalyticsWorkspaceGroup := group[1]
 		upstreamSpec.LogAnalyticsWorkspaceGroup = to.StringPtr(logAnalyticsWorkspaceGroup)
 
-		logAnalyticsWorkspaceName := matchWorkspaceName.FindStringSubmatch(to.String(logAnalyticsWorkspaceResourceID))[1]
+		name := matchWorkspaceName.FindStringSubmatch(to.String(logAnalyticsWorkspaceResourceID))
+		if name == nil {
+			return nil, fmt.Errorf("OMS Agent configuration workspace group was not found")
+		}
+		logAnalyticsWorkspaceName := name[1]
 		upstreamSpec.LogAnalyticsWorkspaceName = to.StringPtr(logAnalyticsWorkspaceName)
 	}
 


### PR DESCRIPTION
Issue: https://github.com/rancher/rancher/issues/39259
<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

When a customer creates an AKS cluster in Azure portal with monitoring configured (OMS agent profile), then import it into Rancher, Rancher will panic [here](https://github.com/rancher/aks-operator/blob/dc721007245a04f953523e91e01174b79f104e1e/controller/aks-cluster-config-handler.go#L700) because in this upstream config

```
"addonProfiles": {
    "omsagent": {
      "config": {
        "logAnalyticsWorkspaceResourceID": "/subscriptions/<workspace subscription id>/resourcegroups/<workspace group>/providers/microsoft.operationalinsights/workspaces/<workspace name>"
      },
      "enabled": true
    }
  }
```

The `logAnalyticsWorkspaceResourceID` contains `resourceGroups` instead of `resourcegroups` like Rancher expects [here](https://github.com/rancher/aks-operator/blob/dc721007245a04f953523e91e01174b79f104e1e/controller/aks-cluster-config-handler.go#L82).

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

I added
* Case-insensitive regexp so either `resourceGroups` or `resourcegroups` will be accepted
* Checks for regexp results before pulling the workspace group/name

## Testing

### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!--If you added/updated unit/integration/validation tests, describe what cases they cover and do not cover. -->

### QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regression Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->