### PR TITLE
Pass node pool's subnet id to azure client

### DIFF
--- a/charts/aks-operator-crd/templates/crds.yaml
+++ b/charts/aks-operator-crd/templates/crds.yaml
@@ -122,6 +122,9 @@ spec:
                     vmSize:
                       nullable: true
                       type: string
+                    vnetSubnetID:
+                      nullable: true
+                      type: string
                   type: object
                 nullable: true
                 type: array

--- a/controller/aks-cluster-config-handler.go
+++ b/controller/aks-cluster-config-handler.go
@@ -617,6 +617,7 @@ func (h *Handler) buildUpstreamClusterState(ctx context.Context, spec *aksv1.AKS
 			upstreamNP.MaxCount = np.MaxCount
 			upstreamNP.MinCount = np.MinCount
 		}
+		upstreamNP.VnetSubnetID = np.VnetSubnetID
 		upstreamSpec.NodePools = append(upstreamSpec.NodePools, upstreamNP)
 	}
 
@@ -797,6 +798,10 @@ func (h *Handler) updateUpstreamClusterState(ctx context.Context, config *aksv1.
 			updateNodePool := false
 			upstreamNodePool, ok := upstreamNodePools[npName]
 			if ok {
+				if upstreamNodePool.VnetSubnetID != nil {
+					np.VnetSubnetID = upstreamNodePool.VnetSubnetID
+				}
+
 				if to.Bool(np.EnableAutoScaling) {
 					// Count can't be updated when EnableAutoScaling is true, so don't send anything.
 					np.Count = nil

--- a/pkg/aks/create.go
+++ b/pkg/aks/create.go
@@ -351,6 +351,7 @@ func CreateOrUpdateAgentPool(ctx context.Context, agentPoolClient services.Agent
 		EnableAutoScaling:   np.EnableAutoScaling,
 		MinCount:            np.MinCount,
 		MaxCount:            np.MaxCount,
+		VnetSubnetID:        np.VnetSubnetID,
 	}
 
 	_, err := agentPoolClient.CreateOrUpdate(ctx, spec.ResourceGroup, spec.ClusterName, to.String(np.Name), containerservice.AgentPool{

--- a/pkg/apis/aks.cattle.io/v1/types.go
+++ b/pkg/apis/aks.cattle.io/v1/types.go
@@ -84,4 +84,5 @@ type AKSNodePool struct {
 	MaxCount            *int32    `json:"maxCount,omitempty"`
 	MinCount            *int32    `json:"minCount,omitempty"`
 	EnableAutoScaling   *bool     `json:"enableAutoScaling,omitempty"`
+	VnetSubnetID        *string   `json:"vnetSubnetID,omitempty" norman:"pointer"`
 }

--- a/pkg/apis/aks.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/aks.cattle.io/v1/zz_generated_deepcopy.go
@@ -303,6 +303,11 @@ func (in *AKSNodePool) DeepCopyInto(out *AKSNodePool) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.VnetSubnetID != nil {
+		in, out := &in.VnetSubnetID, &out.VnetSubnetID
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Currently, node pool's subnet id is not set when the operator updates a node pool. This makes azure client try to delete it if the value is set to nil. The PR should fix by passing this value if possible.

Fixes: https://github.com/rancher/rancher/issues/40087