### PR TITLE
Check nil value for aksCluster AddonProfiles

### DIFF
--- a/pkg/aks/create.go
+++ b/pkg/aks/create.go
@@ -91,6 +91,9 @@ func UpdateCluster(ctx context.Context, cred *Credentials, clusterClient service
 
 	// Add/update addon profiles (this will keep separate profiles added by AKS). This code will also add/update addon
 	// profiles for http application routing and monitoring.
+	if aksCluster.AddonProfiles == nil {
+		aksCluster.AddonProfiles = map[string]*containerservice.ManagedClusterAddonProfile{}
+	}
 	for profile := range managedCluster.AddonProfiles {
 		aksCluster.AddonProfiles[profile] = managedCluster.AddonProfiles[profile]
 	}


### PR DESCRIPTION
For changing AddonProfiles for imported AKS cluster, we have to check first if AddonProfiles for aksCluster spec is not nil. If yes then it has to be initialized.

Fixes: https://github.com/rancher/rancher/issues/40087
Signed-off-by: Michal Jura <mjura@suse.com>