### PR TITLE
Add more unit tests for azure services

### DIFF
--- a/pkg/aks/check.go
+++ b/pkg/aks/check.go
@@ -113,7 +113,7 @@ var regionToOmsRegionMap = map[string]string{
 	"chinanorth2": "chinaeast2",
 }
 
-func CheckLogAnalyticsWorkspaceForMonitoring(ctx context.Context, client services.WorkplacesClientInterface,
+func checkLogAnalyticsWorkspaceForMonitoring(ctx context.Context, client services.WorkplacesClientInterface,
 	location string, group string, wsg string, wsn string) (workspaceID string, err error) {
 
 	workspaceRegion, ok := regionToOmsRegionMap[location]

--- a/pkg/aks/check_test.go
+++ b/pkg/aks/check_test.go
@@ -1,8 +1,15 @@
 package aks
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/operationalinsights/mgmt/2020-08-01/operationalinsights"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/aks-operator/pkg/aks/services/mock_services"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,3 +31,83 @@ func Test_generateUniqueLogWorkspace(t *testing.T) {
 		assert.Len(t, got, 63)
 	}
 }
+
+var _ = Describe("checkLogAnalyticsWorkspaceForMonitoring", func() {
+	var (
+		workplacesClientMock *mock_services.MockWorkplacesClientInterface
+		mockController       *gomock.Controller
+	)
+
+	BeforeEach(func() {
+		mockController = gomock.NewController(GinkgoT())
+		workplacesClientMock = mock_services.NewMockWorkplacesClientInterface(mockController)
+	})
+
+	AfterEach(func() {
+		mockController.Finish()
+	})
+
+	It("should return workspaceID if workspace already exists", func() {
+		workspaceName := "workspaceName"
+		workspaceResourceGroup := "resourcegroup"
+		id := "workspaceID"
+		workplacesClientMock.EXPECT().Get(ctx, workspaceResourceGroup, workspaceName).Return(operationalinsights.Workspace{
+			ID: &id,
+		}, nil)
+		workspaceID, err := checkLogAnalyticsWorkspaceForMonitoring(ctx,
+			workplacesClientMock,
+			"eastus", workspaceResourceGroup, "", workspaceName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(workspaceID).To(Equal(id))
+	})
+
+	It("should create workspace if it doesn't exist", func() {
+		workspaceName := "workspaceName"
+		workspaceResourceGroup := "resourcegroup"
+		id := "workspaceID"
+		workplacesClientMock.EXPECT().Get(ctx, workspaceResourceGroup, workspaceName).Return(operationalinsights.Workspace{}, errors.New("not found"))
+		workplacesClientMock.EXPECT().CreateOrUpdate(ctx, workspaceResourceGroup, workspaceName,
+			operationalinsights.Workspace{
+				Location: to.StringPtr("eastus"),
+				WorkspaceProperties: &operationalinsights.WorkspaceProperties{
+					Sku: &operationalinsights.WorkspaceSku{
+						Name: operationalinsights.WorkspaceSkuNameEnumStandalone,
+					},
+				},
+			},
+		).Return(operationalinsights.WorkspacesCreateOrUpdateFuture{}, nil)
+		workplacesClientMock.EXPECT().AsyncCreateUpdateResult(gomock.Any()).Return(operationalinsights.Workspace{
+			ID: &id,
+		}, nil)
+
+		workspaceID, err := checkLogAnalyticsWorkspaceForMonitoring(ctx,
+			workplacesClientMock,
+			"eastus", workspaceResourceGroup, "", workspaceName)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(workspaceID).To(Equal(id))
+	})
+
+	It("should fail if CreateOrUpdate returns error", func() {
+		workplacesClientMock.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(operationalinsights.Workspace{}, errors.New("not found"))
+		workplacesClientMock.EXPECT().CreateOrUpdate(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(operationalinsights.WorkspacesCreateOrUpdateFuture{}, errors.New("error"))
+
+		_, err := checkLogAnalyticsWorkspaceForMonitoring(ctx,
+			workplacesClientMock,
+			"eastus", "workspaceResourceGroup", "", "workspaceName")
+
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should fail if AsyncCreateUpdateResult returns error", func() {
+		workplacesClientMock.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(operationalinsights.Workspace{}, errors.New("not found"))
+		workplacesClientMock.EXPECT().CreateOrUpdate(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(operationalinsights.WorkspacesCreateOrUpdateFuture{}, nil)
+		workplacesClientMock.EXPECT().AsyncCreateUpdateResult(gomock.Any()).Return(operationalinsights.Workspace{}, errors.New("error"))
+
+		_, err := checkLogAnalyticsWorkspaceForMonitoring(ctx,
+			workplacesClientMock,
+			"eastus", "workspaceResourceGroup", "", "workspaceName")
+
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/pkg/aks/create.go
+++ b/pkg/aks/create.go
@@ -10,7 +10,6 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/rancher/aks-operator/pkg/aks/services"
 	aksv1 "github.com/rancher/aks-operator/pkg/apis/aks.cattle.io/v1"
-	"github.com/sirupsen/logrus"
 )
 
 func CreateResourceGroup(ctx context.Context, groupsClient services.ResourceGroupsClientInterface, spec *aksv1.AKSClusterConfigSpec) error {
@@ -45,135 +44,11 @@ func CreateCluster(ctx context.Context, cred *Credentials, clusterClient service
 	return err
 }
 
-// UpdateCluster updates an existing managed Kubernetes cluster. Before updating, it pulls any existing configuration
-// and then only updates managed fields.
-func UpdateCluster(ctx context.Context, cred *Credentials, clusterClient services.ManagedClustersClientInterface, workplaceClient services.WorkplacesClientInterface,
-	spec *aksv1.AKSClusterConfigSpec, phase string) error {
-
-	// Create a new managed cluster from the AKS cluster config
-	managedCluster, err := createManagedCluster(ctx, cred, workplaceClient, spec, phase)
-	if err != nil {
-		return err
-	}
-
-	// Pull the upstream cluster state
-	aksCluster, err := clusterClient.Get(ctx, spec.ResourceGroup, spec.ClusterName)
-	if err != nil {
-		logrus.Errorf("Error getting upstream AKS cluster by name [%s]: %s", spec.ClusterName, err.Error())
-		return err
-	}
-
-	// Upstream cluster state was successfully pulled. Merge in updates without overwriting upstream fields: we never
-	// want to overwrite preconfigured values in Azure with nil values. So only update fields pulled from AKS with
-	// values from the managed cluster if they are non nil.
-
-	/*
-		The following fields are managed in Rancher but are NOT configurable on update
-		- Name
-		- Location
-		- DNSPrefix
-		- EnablePrivateCluster
-		- LoadBalancerProfile
-	*/
-
-	// Update kubernetes version
-	// If a cluster is imported, we may not have the kubernetes version set on the spec.
-	if managedCluster.KubernetesVersion != nil {
-		aksCluster.KubernetesVersion = managedCluster.KubernetesVersion
-	}
-
-	// Add/update agent pool profiles
-	for _, ap := range *managedCluster.AgentPoolProfiles {
-		if !hasAgentPoolProfile(ap.Name, aksCluster.AgentPoolProfiles) {
-			*aksCluster.AgentPoolProfiles = append(*aksCluster.AgentPoolProfiles, ap)
-		}
-	}
-
-	// Add/update addon profiles (this will keep separate profiles added by AKS). This code will also add/update addon
-	// profiles for http application routing and monitoring.
-	if aksCluster.AddonProfiles == nil {
-		aksCluster.AddonProfiles = map[string]*containerservice.ManagedClusterAddonProfile{}
-	}
-	for profile := range managedCluster.AddonProfiles {
-		aksCluster.AddonProfiles[profile] = managedCluster.AddonProfiles[profile]
-	}
-
-	// Auth IP ranges
-	// note: there could be authorized IP ranges set in AKS that haven't propagated yet when this update is done. Add
-	// ranges from Rancher to any ones already set in AKS.
-	if managedCluster.APIServerAccessProfile != nil && managedCluster.APIServerAccessProfile.AuthorizedIPRanges != nil {
-
-		for index := range *managedCluster.APIServerAccessProfile.AuthorizedIPRanges {
-			ipRange := (*managedCluster.APIServerAccessProfile.AuthorizedIPRanges)[index]
-
-			if !hasAuthorizedIPRange(ipRange, aksCluster.APIServerAccessProfile.AuthorizedIPRanges) {
-				*aksCluster.APIServerAccessProfile.AuthorizedIPRanges = append(*aksCluster.APIServerAccessProfile.AuthorizedIPRanges, ipRange)
-			}
-		}
-	}
-
-	// Linux profile
-	if managedCluster.LinuxProfile != nil {
-		aksCluster.LinuxProfile = managedCluster.LinuxProfile
-	}
-
-	// Network profile
-	if managedCluster.NetworkProfile != nil {
-		np := managedCluster.NetworkProfile
-		if np.NetworkPlugin != "" {
-			aksCluster.NetworkProfile.NetworkPlugin = np.NetworkPlugin
-		}
-		if np.NetworkPolicy != "" {
-			aksCluster.NetworkProfile.NetworkPolicy = np.NetworkPolicy
-		}
-		if np.NetworkMode != "" {
-			aksCluster.NetworkProfile.NetworkMode = np.NetworkMode
-		}
-		if np.DNSServiceIP != nil {
-			aksCluster.NetworkProfile.DNSServiceIP = np.DNSServiceIP
-		}
-		if np.DockerBridgeCidr != nil {
-			aksCluster.NetworkProfile.DockerBridgeCidr = np.DockerBridgeCidr
-		}
-		if np.PodCidr != nil {
-			aksCluster.NetworkProfile.PodCidr = np.PodCidr
-		}
-		if np.ServiceCidr != nil {
-			aksCluster.NetworkProfile.ServiceCidr = np.ServiceCidr
-		}
-		if np.OutboundType != "" {
-			aksCluster.NetworkProfile.OutboundType = np.OutboundType
-		}
-		if np.LoadBalancerSku != "" {
-			aksCluster.NetworkProfile.LoadBalancerSku = np.LoadBalancerSku
-		}
-		// LoadBalancerProfile is not configurable in Rancher so there won't be subfield conflicts. Just pull it from
-		// the state in AKS.
-	}
-
-	// Service principal client id and secret
-	if managedCluster.ServicePrincipalProfile != nil { // operator phase is 'updating' or 'active'
-		aksCluster.ServicePrincipalProfile = managedCluster.ServicePrincipalProfile
-	}
-
-	// Tags
-	if managedCluster.Tags != nil {
-		aksCluster.Tags = managedCluster.Tags
-	}
-
-	_, err = clusterClient.CreateOrUpdate(
-		ctx,
-		spec.ResourceGroup,
-		spec.ClusterName,
-		aksCluster,
-	)
-
-	return err
-}
-
 // createManagedCluster creates a new managed Kubernetes cluster.
 func createManagedCluster(ctx context.Context, cred *Credentials, workplacesClient services.WorkplacesClientInterface, spec *aksv1.AKSClusterConfigSpec, phase string) (containerservice.ManagedCluster, error) {
-	managedCluster := containerservice.ManagedCluster{}
+	managedCluster := containerservice.ManagedCluster{
+		ManagedClusterProperties: &containerservice.ManagedClusterProperties{},
+	}
 
 	// Get tags from config spec
 	tags := make(map[string]*string)
@@ -281,7 +156,7 @@ func createManagedCluster(ctx context.Context, cred *Credentials, workplacesClie
 			Enabled: spec.Monitoring,
 		}
 
-		logAnalyticsWorkspaceResourceID, err := CheckLogAnalyticsWorkspaceForMonitoring(ctx, workplacesClient,
+		logAnalyticsWorkspaceResourceID, err := checkLogAnalyticsWorkspaceForMonitoring(ctx, workplacesClient,
 			spec.ResourceLocation, spec.ResourceGroup, to.String(spec.LogAnalyticsWorkspaceGroup), to.String(spec.LogAnalyticsWorkspaceName))
 		if err != nil {
 			return managedCluster, err
@@ -323,15 +198,18 @@ func createManagedCluster(ctx context.Context, cred *Credentials, workplacesClie
 	}
 
 	if spec.AuthorizedIPRanges != nil {
-		managedCluster.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{
-			AuthorizedIPRanges: spec.AuthorizedIPRanges,
+		if managedCluster.APIServerAccessProfile == nil {
+			managedCluster.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{}
 		}
+		managedCluster.APIServerAccessProfile.AuthorizedIPRanges = spec.AuthorizedIPRanges
+
 	}
 
 	if to.Bool(spec.PrivateCluster) {
-		managedCluster.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{
-			EnablePrivateCluster: spec.PrivateCluster,
+		if managedCluster.APIServerAccessProfile == nil {
+			managedCluster.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{}
 		}
+		managedCluster.APIServerAccessProfile.EnablePrivateCluster = spec.PrivateCluster
 	}
 
 	return managedCluster, nil

--- a/pkg/aks/create_test.go
+++ b/pkg/aks/create_test.go
@@ -70,48 +70,8 @@ var _ = Describe("newManagedCluster", func() {
 	BeforeEach(func() {
 		mockController = gomock.NewController(GinkgoT())
 		workplacesClientMock = mock_services.NewMockWorkplacesClientInterface(mockController)
-		clusterSpec = &aksv1.AKSClusterConfigSpec{
-			ResourceLocation: "eastus",
-			Tags: map[string]string{
-				"test-tag": "test-value",
-			},
-			NetworkPolicy:           to.StringPtr("calico"),
-			NetworkPlugin:           to.StringPtr("azure"),
-			NetworkDNSServiceIP:     to.StringPtr("test-dns-service-ip"),
-			NetworkDockerBridgeCIDR: to.StringPtr("test-docker-bridge-cidr"),
-			NetworkServiceCIDR:      to.StringPtr("test-service-cidr"),
-			NetworkPodCIDR:          to.StringPtr("test-pod-cidr"),
-			ResourceGroup:           "test-rg",
-			VirtualNetwork:          to.StringPtr("test-virtual-network"),
-			Subnet:                  to.StringPtr("test-subnet"),
-			NodePools: []aksv1.AKSNodePool{
-				{
-					Name:                to.StringPtr("test-node-pool"),
-					Count:               to.Int32Ptr(1),
-					MaxPods:             to.Int32Ptr(1),
-					OsDiskSizeGB:        to.Int32Ptr(1),
-					OsDiskType:          "Ephemeral",
-					OsType:              "Linux",
-					VMSize:              "Standard_D2_v2",
-					Mode:                "System",
-					OrchestratorVersion: to.StringPtr("test-orchestrator-version"),
-					AvailabilityZones:   to.StringSlicePtr([]string{"test-availability-zone"}),
-					EnableAutoScaling:   to.BoolPtr(true),
-					MinCount:            to.Int32Ptr(1),
-					MaxCount:            to.Int32Ptr(2),
-				},
-			},
-			LinuxAdminUsername:         to.StringPtr("test-admin-username"),
-			LinuxSSHPublicKey:          to.StringPtr("test-ssh-public-key"),
-			HTTPApplicationRouting:     to.BoolPtr(true),
-			Monitoring:                 to.BoolPtr(true),
-			KubernetesVersion:          to.StringPtr("test-kubernetes-version"),
-			DNSPrefix:                  to.StringPtr("test-dns-prefix"),
-			AuthorizedIPRanges:         to.StringSlicePtr([]string{"test-authorized-ip-range"}),
-			PrivateCluster:             to.BoolPtr(true),
-			LogAnalyticsWorkspaceGroup: to.StringPtr("test-log-analytics-workspace-group"),
-			LogAnalyticsWorkspaceName:  to.StringPtr("test-log-analytics-workspace-name"),
-		}
+		clusterSpec = newTestClusterSpec()
+		clusterSpec.Monitoring = to.BoolPtr(true)
 		cred = &Credentials{
 			ClientID:     "test-client-id",
 			ClientSecret: "test-client-secret",
@@ -346,10 +306,7 @@ var _ = Describe("CreateCluster", func() {
 		mockController = gomock.NewController(GinkgoT())
 		workplacesClientMock = mock_services.NewMockWorkplacesClientInterface(mockController)
 		clusterClientMock = mock_services.NewMockManagedClustersClientInterface(mockController)
-		clusterSpec = &aksv1.AKSClusterConfigSpec{
-			ClusterName:   "test-cluster",
-			ResourceGroup: "test-rg",
-		}
+		clusterSpec = newTestClusterSpec()
 	})
 
 	AfterEach(func() {
@@ -380,10 +337,7 @@ var _ = Describe("CreateOrUpdateAgentPool", func() {
 	BeforeEach(func() {
 		mockController = gomock.NewController(GinkgoT())
 		agentPoolClientMock = mock_services.NewMockAgentPoolsClientInterface(mockController)
-		clusterSpec = &aksv1.AKSClusterConfigSpec{
-			ClusterName:   "test-cluster",
-			ResourceGroup: "test-rg",
-		}
+		clusterSpec = newTestClusterSpec()
 		nodePoolSpec = &aksv1.AKSNodePool{
 			Name:                to.StringPtr("test-nodepool"),
 			Count:               to.Int32Ptr(1),
@@ -436,3 +390,48 @@ var _ = Describe("CreateOrUpdateAgentPool", func() {
 		Expect(CreateOrUpdateAgentPool(ctx, agentPoolClientMock, clusterSpec, nodePoolSpec)).ToNot(Succeed())
 	})
 })
+
+func newTestClusterSpec() *aksv1.AKSClusterConfigSpec {
+	return &aksv1.AKSClusterConfigSpec{
+		ResourceLocation: "eastus",
+		Tags: map[string]string{
+			"test-tag": "test-value",
+		},
+		NetworkPolicy:           to.StringPtr("calico"),
+		NetworkPlugin:           to.StringPtr("azure"),
+		NetworkDNSServiceIP:     to.StringPtr("test-dns-service-ip"),
+		NetworkDockerBridgeCIDR: to.StringPtr("test-docker-bridge-cidr"),
+		NetworkServiceCIDR:      to.StringPtr("test-service-cidr"),
+		NetworkPodCIDR:          to.StringPtr("test-pod-cidr"),
+		ResourceGroup:           "test-rg",
+		VirtualNetwork:          to.StringPtr("test-virtual-network"),
+		Subnet:                  to.StringPtr("test-subnet"),
+		NodePools: []aksv1.AKSNodePool{
+			{
+				Name:                to.StringPtr("test-node-pool"),
+				Count:               to.Int32Ptr(1),
+				MaxPods:             to.Int32Ptr(1),
+				OsDiskSizeGB:        to.Int32Ptr(1),
+				OsDiskType:          "Ephemeral",
+				OsType:              "Linux",
+				VMSize:              "Standard_D2_v2",
+				Mode:                "System",
+				OrchestratorVersion: to.StringPtr("test-orchestrator-version"),
+				AvailabilityZones:   to.StringSlicePtr([]string{"test-availability-zone"}),
+				EnableAutoScaling:   to.BoolPtr(true),
+				MinCount:            to.Int32Ptr(1),
+				MaxCount:            to.Int32Ptr(2),
+			},
+		},
+		LinuxAdminUsername:         to.StringPtr("test-admin-username"),
+		LinuxSSHPublicKey:          to.StringPtr("test-ssh-public-key"),
+		HTTPApplicationRouting:     to.BoolPtr(true),
+		Monitoring:                 to.BoolPtr(false),
+		KubernetesVersion:          to.StringPtr("test-kubernetes-version"),
+		DNSPrefix:                  to.StringPtr("test-dns-prefix"),
+		AuthorizedIPRanges:         to.StringSlicePtr([]string{"test-authorized-ip-range"}),
+		PrivateCluster:             to.BoolPtr(true),
+		LogAnalyticsWorkspaceGroup: to.StringPtr("test-log-analytics-workspace-group"),
+		LogAnalyticsWorkspaceName:  to.StringPtr("test-log-analytics-workspace-name"),
+	}
+}

--- a/pkg/aks/create_test.go
+++ b/pkg/aks/create_test.go
@@ -3,7 +3,10 @@ package aks
 import (
 	"errors"
 
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-11-01/containerservice"
+	"github.com/Azure/azure-sdk-for-go/services/operationalinsights/mgmt/2020-08-01/operationalinsights"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-10-01/resources"
+
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -14,45 +17,422 @@ import (
 
 var _ = Describe("CreateResourceGroup", func() {
 	var (
-		mockCtrl          *gomock.Controller
-		rgClientMock      *mock_services.MockResourceGroupsClientInterface
-		resourceGroupName = "test-rg"
-		location          = "eastus"
+		mockController          *gomock.Controller
+		mockResourceGroupClient *mock_services.MockResourceGroupsClientInterface
+		resourceGroupName       = "test-rg"
+		location                = "eastus"
 	)
 
 	BeforeEach(func() {
-		mockCtrl = gomock.NewController(GinkgoT())
-		rgClientMock = mock_services.NewMockResourceGroupsClientInterface(mockCtrl)
+		mockController = gomock.NewController(GinkgoT())
+		mockResourceGroupClient = mock_services.NewMockResourceGroupsClientInterface(mockController)
 	})
 
 	AfterEach(func() {
-		mockCtrl.Finish()
+		mockController.Finish()
 	})
 
-	It("should succefully create a resource group", func() {
-
-		rgClientMock.EXPECT().CreateOrUpdate(ctx, resourceGroupName, resources.Group{
+	It("should successfully create a resource group", func() {
+		mockResourceGroupClient.EXPECT().CreateOrUpdate(ctx, resourceGroupName, resources.Group{
 			Name:     to.StringPtr(resourceGroupName),
 			Location: to.StringPtr(location),
 		}).Return(resources.Group{}, nil)
 
-		Expect(CreateResourceGroup(ctx, rgClientMock, &aksv1.AKSClusterConfigSpec{
+		Expect(CreateResourceGroup(ctx, mockResourceGroupClient, &aksv1.AKSClusterConfigSpec{
 			ResourceGroup:    resourceGroupName,
 			ResourceLocation: location,
 		})).To(Succeed())
 	})
 
 	It("should catch error when resource group creation fails", func() {
-		rgClientMock.EXPECT().CreateOrUpdate(ctx, resourceGroupName, resources.Group{
+		mockResourceGroupClient.EXPECT().CreateOrUpdate(ctx, resourceGroupName, resources.Group{
 			Name:     to.StringPtr(resourceGroupName),
 			Location: to.StringPtr(location),
 		}).Return(resources.Group{}, errors.New("failed to create resource group"))
 
-		err := CreateResourceGroup(ctx, rgClientMock, &aksv1.AKSClusterConfigSpec{
+		err := CreateResourceGroup(ctx, mockResourceGroupClient, &aksv1.AKSClusterConfigSpec{
 			ResourceGroup:    resourceGroupName,
 			ResourceLocation: location,
 		})
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("failed to create resource group"))
+	})
+})
+
+var _ = Describe("newManagedCluster", func() {
+	var (
+		mockController       *gomock.Controller
+		workplacesClientMock *mock_services.MockWorkplacesClientInterface
+		clusterSpec          *aksv1.AKSClusterConfigSpec
+		cred                 *Credentials
+	)
+
+	BeforeEach(func() {
+		mockController = gomock.NewController(GinkgoT())
+		workplacesClientMock = mock_services.NewMockWorkplacesClientInterface(mockController)
+		clusterSpec = &aksv1.AKSClusterConfigSpec{
+			ResourceLocation: "eastus",
+			Tags: map[string]string{
+				"test-tag": "test-value",
+			},
+			NetworkPolicy:           to.StringPtr("calico"),
+			NetworkPlugin:           to.StringPtr("azure"),
+			NetworkDNSServiceIP:     to.StringPtr("test-dns-service-ip"),
+			NetworkDockerBridgeCIDR: to.StringPtr("test-docker-bridge-cidr"),
+			NetworkServiceCIDR:      to.StringPtr("test-service-cidr"),
+			NetworkPodCIDR:          to.StringPtr("test-pod-cidr"),
+			ResourceGroup:           "test-rg",
+			VirtualNetwork:          to.StringPtr("test-virtual-network"),
+			Subnet:                  to.StringPtr("test-subnet"),
+			NodePools: []aksv1.AKSNodePool{
+				{
+					Name:                to.StringPtr("test-node-pool"),
+					Count:               to.Int32Ptr(1),
+					MaxPods:             to.Int32Ptr(1),
+					OsDiskSizeGB:        to.Int32Ptr(1),
+					OsDiskType:          "Ephemeral",
+					OsType:              "Linux",
+					VMSize:              "Standard_D2_v2",
+					Mode:                "System",
+					OrchestratorVersion: to.StringPtr("test-orchestrator-version"),
+					AvailabilityZones:   to.StringSlicePtr([]string{"test-availability-zone"}),
+					EnableAutoScaling:   to.BoolPtr(true),
+					MinCount:            to.Int32Ptr(1),
+					MaxCount:            to.Int32Ptr(2),
+				},
+			},
+			LinuxAdminUsername:         to.StringPtr("test-admin-username"),
+			LinuxSSHPublicKey:          to.StringPtr("test-ssh-public-key"),
+			HTTPApplicationRouting:     to.BoolPtr(true),
+			Monitoring:                 to.BoolPtr(true),
+			KubernetesVersion:          to.StringPtr("test-kubernetes-version"),
+			DNSPrefix:                  to.StringPtr("test-dns-prefix"),
+			AuthorizedIPRanges:         to.StringSlicePtr([]string{"test-authorized-ip-range"}),
+			PrivateCluster:             to.BoolPtr(true),
+			LogAnalyticsWorkspaceGroup: to.StringPtr("test-log-analytics-workspace-group"),
+			LogAnalyticsWorkspaceName:  to.StringPtr("test-log-analytics-workspace-name"),
+		}
+		cred = &Credentials{
+			ClientID:     "test-client-id",
+			ClientSecret: "test-client-secret",
+		}
+	})
+
+	AfterEach(func() {
+		mockController.Finish()
+	})
+
+	It("should successfully create a managed cluster", func() {
+		workplacesClientMock.EXPECT().Get(ctx, to.String(clusterSpec.LogAnalyticsWorkspaceGroup), to.String(clusterSpec.LogAnalyticsWorkspaceName)).
+			Return(operationalinsights.Workspace{
+				ID: to.StringPtr("test-workspace-id"),
+			}, nil)
+
+		managedCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "test-phase")
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(managedCluster.Tags).To(HaveKeyWithValue("test-tag", to.StringPtr("test-value")))
+		Expect(managedCluster.NetworkProfile.NetworkPolicy).To(Equal(containerservice.NetworkPolicy(to.String(clusterSpec.NetworkPolicy))))
+		Expect(managedCluster.NetworkProfile.LoadBalancerSku).To(Equal(containerservice.Standard))
+		Expect(managedCluster.NetworkProfile.NetworkPlugin).To(Equal(containerservice.NetworkPlugin(to.String(clusterSpec.NetworkPlugin))))
+		Expect(managedCluster.NetworkProfile.DNSServiceIP).To(Equal(clusterSpec.NetworkDNSServiceIP))
+		Expect(managedCluster.NetworkProfile.DockerBridgeCidr).To(Equal(clusterSpec.NetworkDockerBridgeCIDR))
+		Expect(managedCluster.NetworkProfile.ServiceCidr).To(Equal(clusterSpec.NetworkServiceCIDR))
+		Expect(managedCluster.NetworkProfile.PodCidr).To(Equal(clusterSpec.NetworkPodCIDR))
+		agentPoolProfiles := *managedCluster.AgentPoolProfiles
+		Expect(agentPoolProfiles).To(HaveLen(1))
+		Expect(agentPoolProfiles[0].Name).To(Equal(clusterSpec.NodePools[0].Name))
+		Expect(agentPoolProfiles[0].Count).To(Equal(clusterSpec.NodePools[0].Count))
+		Expect(agentPoolProfiles[0].MaxPods).To(Equal(clusterSpec.NodePools[0].MaxPods))
+		Expect(agentPoolProfiles[0].OsDiskSizeGB).To(Equal(clusterSpec.NodePools[0].OsDiskSizeGB))
+		Expect(agentPoolProfiles[0].OsDiskType).To(Equal(containerservice.OSDiskType(clusterSpec.NodePools[0].OsDiskType)))
+		Expect(agentPoolProfiles[0].OsType).To(Equal(containerservice.OSType(clusterSpec.NodePools[0].OsType)))
+		Expect(agentPoolProfiles[0].VMSize).To(Equal(containerservice.VMSizeTypes(clusterSpec.NodePools[0].VMSize)))
+		Expect(agentPoolProfiles[0].Mode).To(Equal(containerservice.AgentPoolMode(clusterSpec.NodePools[0].Mode)))
+		Expect(agentPoolProfiles[0].OrchestratorVersion).To(Equal(clusterSpec.NodePools[0].OrchestratorVersion))
+		expectedAvailabilityZones := *agentPoolProfiles[0].AvailabilityZones
+		clusterSpecAvailabilityZones := *clusterSpec.NodePools[0].AvailabilityZones
+		Expect(expectedAvailabilityZones).To(HaveLen(1))
+		Expect(expectedAvailabilityZones[0]).To(Equal(clusterSpecAvailabilityZones[0]))
+		Expect(agentPoolProfiles[0].EnableAutoScaling).To(Equal(clusterSpec.NodePools[0].EnableAutoScaling))
+		Expect(agentPoolProfiles[0].MinCount).To(Equal(clusterSpec.NodePools[0].MinCount))
+		Expect(agentPoolProfiles[0].MaxCount).To(Equal(clusterSpec.NodePools[0].MaxCount))
+		Expect(managedCluster.LinuxProfile.AdminUsername).To(Equal(clusterSpec.LinuxAdminUsername))
+		sshPublicKeys := *managedCluster.LinuxProfile.SSH.PublicKeys
+		Expect(sshPublicKeys).To(HaveLen(1))
+		Expect(sshPublicKeys[0].KeyData).To(Equal(clusterSpec.LinuxSSHPublicKey))
+		Expect(managedCluster.AddonProfiles).To(HaveKey("httpApplicationRouting"))
+		Expect(managedCluster.AddonProfiles["httpApplicationRouting"].Enabled).To(Equal(clusterSpec.HTTPApplicationRouting))
+		Expect(managedCluster.AddonProfiles).To(HaveKey("omsAgent"))
+		Expect(managedCluster.AddonProfiles["omsAgent"].Enabled).To(Equal(clusterSpec.Monitoring))
+		Expect(managedCluster.AddonProfiles["omsAgent"].Config).To(HaveKeyWithValue("logAnalyticsWorkspaceResourceID", to.StringPtr("/test-workspace-id")))
+		Expect(managedCluster.Location).To(Equal(to.StringPtr(clusterSpec.ResourceLocation)))
+		Expect(managedCluster.KubernetesVersion).To(Equal(clusterSpec.KubernetesVersion))
+		Expect(managedCluster.ServicePrincipalProfile).ToNot(BeNil())
+		Expect(managedCluster.ServicePrincipalProfile.ClientID).To(Equal(to.StringPtr(cred.ClientID)))
+		Expect(managedCluster.ServicePrincipalProfile.Secret).To(Equal(to.StringPtr(cred.ClientSecret)))
+		Expect(managedCluster.DNSPrefix).To(Equal(clusterSpec.DNSPrefix))
+		Expect(managedCluster.APIServerAccessProfile).ToNot(BeNil())
+		Expect(managedCluster.APIServerAccessProfile.AuthorizedIPRanges).ToNot(BeNil())
+		ipRanges := *managedCluster.APIServerAccessProfile.AuthorizedIPRanges
+		clusterSpecIPRanges := *clusterSpec.AuthorizedIPRanges
+		Expect(ipRanges).To(HaveLen(1))
+		Expect(ipRanges[0]).To(Equal(clusterSpecIPRanges[0]))
+		Expect(managedCluster.APIServerAccessProfile.EnablePrivateCluster).To(Equal(clusterSpec.PrivateCluster))
+	})
+
+	It("should successfully create managed cluster with custom load balancer sku", func() {
+		workplacesClientMock.EXPECT().Get(ctx, to.String(clusterSpec.LogAnalyticsWorkspaceGroup), to.String(clusterSpec.LogAnalyticsWorkspaceName)).
+			Return(operationalinsights.Workspace{
+				ID: to.StringPtr("test-workspace-id"),
+			}, nil)
+		clusterSpec.LoadBalancerSKU = to.StringPtr("basic")
+		managedCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "test-phase")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(managedCluster.NetworkProfile.LoadBalancerSku).To(Equal(containerservice.Basic))
+	})
+
+	It("should successfully create managed cluster with custom network plugin", func() {
+		workplacesClientMock.EXPECT().Get(ctx, to.String(clusterSpec.LogAnalyticsWorkspaceGroup), to.String(clusterSpec.LogAnalyticsWorkspaceName)).
+			Return(operationalinsights.Workspace{
+				ID: to.StringPtr("test-workspace-id"),
+			}, nil)
+		clusterSpec.NetworkPlugin = to.StringPtr("")
+		managedCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "test-phase")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(managedCluster.NetworkProfile.NetworkPlugin).To(Equal(containerservice.Kubenet))
+		Expect(managedCluster.NetworkProfile.DNSServiceIP).To(BeNil())
+		Expect(managedCluster.NetworkProfile.DockerBridgeCidr).To(BeNil())
+		Expect(managedCluster.NetworkProfile.ServiceCidr).To(BeNil())
+		Expect(managedCluster.NetworkProfile.PodCidr).To(BeNil())
+	})
+
+	It("should successfully create managed cluster with custom virtual network resource group", func() {
+		workplacesClientMock.EXPECT().Get(ctx, to.String(clusterSpec.LogAnalyticsWorkspaceGroup), to.String(clusterSpec.LogAnalyticsWorkspaceName)).
+			Return(operationalinsights.Workspace{
+				ID: to.StringPtr("test-workspace-id"),
+			}, nil)
+		clusterSpec.VirtualNetworkResourceGroup = to.StringPtr("test-vnet-resource-group")
+		managedCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "test-phase")
+		Expect(err).ToNot(HaveOccurred())
+
+		agentPoolProfiles := *managedCluster.AgentPoolProfiles
+		Expect(agentPoolProfiles).To(HaveLen(1))
+		Expect(to.String(agentPoolProfiles[0].VnetSubnetID)).To(ContainSubstring(to.String(clusterSpec.VirtualNetworkResourceGroup)))
+	})
+
+	It("should successfully create managed cluster with orchestrator version", func() {
+		workplacesClientMock.EXPECT().Get(ctx, to.String(clusterSpec.LogAnalyticsWorkspaceGroup), to.String(clusterSpec.LogAnalyticsWorkspaceName)).
+			Return(operationalinsights.Workspace{
+				ID: to.StringPtr("test-workspace-id"),
+			}, nil)
+		clusterSpec.NodePools[0].OrchestratorVersion = to.StringPtr("custom-orchestrator-version")
+		managedCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "test-phase")
+		Expect(err).ToNot(HaveOccurred())
+
+		agentPoolProfiles := *managedCluster.AgentPoolProfiles
+		Expect(agentPoolProfiles).To(HaveLen(1))
+		Expect(to.String(agentPoolProfiles[0].OrchestratorVersion)).To(ContainSubstring(to.String(clusterSpec.NodePools[0].OrchestratorVersion)))
+	})
+
+	It("should successfully create managed cluster with no availability zones set", func() {
+		workplacesClientMock.EXPECT().Get(ctx, to.String(clusterSpec.LogAnalyticsWorkspaceGroup), to.String(clusterSpec.LogAnalyticsWorkspaceName)).
+			Return(operationalinsights.Workspace{
+				ID: to.StringPtr("test-workspace-id"),
+			}, nil)
+		clusterSpec.NodePools[0].AvailabilityZones = nil
+		managedCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "test-phase")
+		Expect(err).ToNot(HaveOccurred())
+		agentPoolProfiles := *managedCluster.AgentPoolProfiles
+		Expect(agentPoolProfiles).To(HaveLen(1))
+		Expect(agentPoolProfiles[0].AvailabilityZones).To(BeNil())
+	})
+
+	It("should successfully create managed cluster with no autoscaling enabled", func() {
+		workplacesClientMock.EXPECT().Get(ctx, to.String(clusterSpec.LogAnalyticsWorkspaceGroup), to.String(clusterSpec.LogAnalyticsWorkspaceName)).
+			Return(operationalinsights.Workspace{
+				ID: to.StringPtr("test-workspace-id"),
+			}, nil)
+		clusterSpec.NodePools[0].EnableAutoScaling = nil
+		managedCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "test-phase")
+		Expect(err).ToNot(HaveOccurred())
+		agentPoolProfiles := *managedCluster.AgentPoolProfiles
+		Expect(agentPoolProfiles).To(HaveLen(1))
+		Expect(agentPoolProfiles[0].EnableAutoScaling).To(BeNil())
+		Expect(agentPoolProfiles[0].MaxCount).To(BeNil())
+		Expect(agentPoolProfiles[0].MinCount).To(BeNil())
+	})
+
+	It("should successfully create managed cluster with no custom virtual network", func() {
+		workplacesClientMock.EXPECT().Get(ctx, to.String(clusterSpec.LogAnalyticsWorkspaceGroup), to.String(clusterSpec.LogAnalyticsWorkspaceName)).
+			Return(operationalinsights.Workspace{
+				ID: to.StringPtr("test-workspace-id"),
+			}, nil)
+		clusterSpec.VirtualNetwork = nil
+		managedCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "test-phase")
+		Expect(err).ToNot(HaveOccurred())
+
+		agentPoolProfiles := *managedCluster.AgentPoolProfiles
+		Expect(agentPoolProfiles).To(HaveLen(1))
+		Expect(agentPoolProfiles[0].VnetSubnetID).To(BeNil())
+	})
+
+	It("should successfully create managed cluster with no linux profile", func() {
+		workplacesClientMock.EXPECT().Get(ctx, to.String(clusterSpec.LogAnalyticsWorkspaceGroup), to.String(clusterSpec.LogAnalyticsWorkspaceName)).
+			Return(operationalinsights.Workspace{
+				ID: to.StringPtr("test-workspace-id"),
+			}, nil)
+		clusterSpec.LinuxAdminUsername = nil
+		clusterSpec.LinuxSSHPublicKey = nil
+		managedCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "test-phase")
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(managedCluster.LinuxProfile).To(BeNil())
+	})
+
+	It("should successfully create managed cluster with no http application routing", func() {
+		workplacesClientMock.EXPECT().Get(ctx, to.String(clusterSpec.LogAnalyticsWorkspaceGroup), to.String(clusterSpec.LogAnalyticsWorkspaceName)).
+			Return(operationalinsights.Workspace{
+				ID: to.StringPtr("test-workspace-id"),
+			}, nil)
+		clusterSpec.ResourceLocation = "chinaeast"
+		managedCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "test-phase")
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(managedCluster.AddonProfiles).ToNot(HaveKey("httpApplicationRouting"))
+	})
+
+	It("should successfully create managed cluster with no monitoring enabled", func() {
+		workplacesClientMock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(operationalinsights.Workspace{}, nil).Times(0)
+		clusterSpec.Monitoring = nil
+		managedCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "test-phase")
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(managedCluster.AddonProfiles).ToNot(HaveKey("omsagent"))
+	})
+
+	It("should successfully create managed cluster when phase is set to active", func() {
+		workplacesClientMock.EXPECT().Get(ctx, to.String(clusterSpec.LogAnalyticsWorkspaceGroup), to.String(clusterSpec.LogAnalyticsWorkspaceName)).
+			Return(operationalinsights.Workspace{
+				ID: to.StringPtr("test-workspace-id"),
+			}, nil)
+		managedCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "active")
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(managedCluster.ServicePrincipalProfile).To(BeNil())
+	})
+
+	It("should fail if LogAnalyticsWorkspaceForMonitoring returns error", func() {
+		workplacesClientMock.EXPECT().Get(ctx, to.String(clusterSpec.LogAnalyticsWorkspaceGroup), to.String(clusterSpec.LogAnalyticsWorkspaceName)).
+			Return(operationalinsights.Workspace{}, errors.New("test-error"))
+
+		workplacesClientMock.EXPECT().CreateOrUpdate(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(operationalinsights.WorkspacesCreateOrUpdateFuture{}, errors.New("test-error"))
+
+		_, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "test-phase")
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("CreateCluster", func() {
+	var (
+		mockController       *gomock.Controller
+		workplacesClientMock *mock_services.MockWorkplacesClientInterface
+		clusterClientMock    *mock_services.MockManagedClustersClientInterface
+		clusterSpec          *aksv1.AKSClusterConfigSpec
+	)
+
+	BeforeEach(func() {
+		mockController = gomock.NewController(GinkgoT())
+		workplacesClientMock = mock_services.NewMockWorkplacesClientInterface(mockController)
+		clusterClientMock = mock_services.NewMockManagedClustersClientInterface(mockController)
+		clusterSpec = &aksv1.AKSClusterConfigSpec{
+			ClusterName:   "test-cluster",
+			ResourceGroup: "test-rg",
+		}
+	})
+
+	AfterEach(func() {
+		mockController.Finish()
+	})
+
+	It("should successfully create managed cluster", func() {
+		clusterClientMock.EXPECT().CreateOrUpdate(
+			ctx, clusterSpec.ResourceGroup, clusterSpec.ClusterName, gomock.Any()).Return(containerservice.ManagedClustersCreateOrUpdateFuture{}, nil)
+		Expect(CreateCluster(ctx, &Credentials{}, clusterClientMock, workplacesClientMock, clusterSpec, "test-phase")).To(Succeed())
+	})
+
+	It("should fail if clusterClient.CreateOrUpdate returns error", func() {
+		clusterClientMock.EXPECT().CreateOrUpdate(
+			ctx, clusterSpec.ResourceGroup, clusterSpec.ClusterName, gomock.Any()).Return(containerservice.ManagedClustersCreateOrUpdateFuture{}, errors.New("test-error"))
+		Expect(CreateCluster(ctx, &Credentials{}, clusterClientMock, workplacesClientMock, clusterSpec, "test-phase")).ToNot(Succeed())
+	})
+})
+
+var _ = Describe("CreateOrUpdateAgentPool", func() {
+	var (
+		mockController      *gomock.Controller
+		agentPoolClientMock *mock_services.MockAgentPoolsClientInterface
+		clusterSpec         *aksv1.AKSClusterConfigSpec
+		nodePoolSpec        *aksv1.AKSNodePool
+	)
+
+	BeforeEach(func() {
+		mockController = gomock.NewController(GinkgoT())
+		agentPoolClientMock = mock_services.NewMockAgentPoolsClientInterface(mockController)
+		clusterSpec = &aksv1.AKSClusterConfigSpec{
+			ClusterName:   "test-cluster",
+			ResourceGroup: "test-rg",
+		}
+		nodePoolSpec = &aksv1.AKSNodePool{
+			Name:                to.StringPtr("test-nodepool"),
+			Count:               to.Int32Ptr(1),
+			MaxPods:             to.Int32Ptr(1),
+			OsDiskSizeGB:        to.Int32Ptr(1),
+			OsDiskType:          "Ephemeral",
+			OsType:              "Linux",
+			VMSize:              "Standard_D2_v2",
+			Mode:                "System",
+			OrchestratorVersion: to.StringPtr("test-version"),
+			AvailabilityZones:   to.StringSlicePtr([]string{"test-az"}),
+			EnableAutoScaling:   to.BoolPtr(true),
+			MinCount:            to.Int32Ptr(1),
+			MaxCount:            to.Int32Ptr(2),
+		}
+	})
+
+	AfterEach(func() {
+		mockController.Finish()
+	})
+
+	It("should successfully create agent pool", func() {
+		agentPoolClientMock.EXPECT().CreateOrUpdate(
+			ctx, clusterSpec.ResourceGroup, clusterSpec.ClusterName, to.String(nodePoolSpec.Name),
+			containerservice.AgentPool{
+				ManagedClusterAgentPoolProfileProperties: &containerservice.ManagedClusterAgentPoolProfileProperties{
+					Count:               nodePoolSpec.Count,
+					MaxPods:             nodePoolSpec.MaxPods,
+					OsDiskSizeGB:        nodePoolSpec.OsDiskSizeGB,
+					OsDiskType:          containerservice.OSDiskType(nodePoolSpec.OsDiskType),
+					OsType:              containerservice.OSType(nodePoolSpec.OsType),
+					VMSize:              containerservice.VMSizeTypes(nodePoolSpec.VMSize),
+					Mode:                containerservice.AgentPoolMode(nodePoolSpec.Mode),
+					Type:                containerservice.VirtualMachineScaleSets,
+					OrchestratorVersion: nodePoolSpec.OrchestratorVersion,
+					AvailabilityZones:   nodePoolSpec.AvailabilityZones,
+					EnableAutoScaling:   nodePoolSpec.EnableAutoScaling,
+					MinCount:            nodePoolSpec.MinCount,
+					MaxCount:            nodePoolSpec.MaxCount,
+				},
+			}).Return(containerservice.AgentPoolsCreateOrUpdateFuture{}, nil)
+		Expect(CreateOrUpdateAgentPool(ctx, agentPoolClientMock, clusterSpec, nodePoolSpec)).To(Succeed())
+	})
+
+	It("should fail if agentPoolClient.CreateOrUpdate returns error", func() {
+		agentPoolClientMock.EXPECT().CreateOrUpdate(
+			ctx, clusterSpec.ResourceGroup, clusterSpec.ClusterName, to.String(nodePoolSpec.Name), gomock.Any()).
+			Return(containerservice.AgentPoolsCreateOrUpdateFuture{}, errors.New("test-error"))
+
+		Expect(CreateOrUpdateAgentPool(ctx, agentPoolClientMock, clusterSpec, nodePoolSpec)).ToNot(Succeed())
 	})
 })

--- a/pkg/aks/delete_test.go
+++ b/pkg/aks/delete_test.go
@@ -1,0 +1,40 @@
+package aks
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-11-01/containerservice"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/aks-operator/pkg/aks/services/mock_services"
+	aksv1 "github.com/rancher/aks-operator/pkg/apis/aks.cattle.io/v1"
+)
+
+var _ = Describe("RemoveCluster", func() {
+	var (
+		mockController    *gomock.Controller
+		clusterClientMock *mock_services.MockManagedClustersClientInterface
+		clusterSpec       *aksv1.AKSClusterConfigSpec
+	)
+
+	BeforeEach(func() {
+		mockController = gomock.NewController(GinkgoT())
+		clusterClientMock = mock_services.NewMockManagedClustersClientInterface(mockController)
+		clusterSpec = &aksv1.AKSClusterConfigSpec{
+			ResourceGroup: "resourcegroup",
+			ClusterName:   "clustername",
+		}
+	})
+
+	AfterEach(func() {
+		mockController.Finish()
+	})
+
+	It("should successfully delete cluster", func() {
+		clusterClientMock.EXPECT().Delete(ctx, clusterSpec.ResourceGroup, clusterSpec.ClusterName).Return(containerservice.ManagedClustersDeleteFuture{
+			FutureAPI: &azure.Future{},
+		}, nil)
+		clusterClientMock.EXPECT().WaitForTaskCompletion(ctx, gomock.Any()).Return(nil)
+		Expect(RemoveCluster(ctx, clusterClientMock, clusterSpec)).To(Succeed())
+	})
+})

--- a/pkg/aks/update.go
+++ b/pkg/aks/update.go
@@ -5,8 +5,161 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-11-01/containerservice"
 	"github.com/rancher/aks-operator/pkg/aks/services"
+	aksv1 "github.com/rancher/aks-operator/pkg/apis/aks.cattle.io/v1"
+	"github.com/sirupsen/logrus"
 )
 
 func UpdateClusterTags(ctx context.Context, clusterClient services.ManagedClustersClientInterface, resourceGroupName string, resourceName string, parameters containerservice.TagsObject) (containerservice.ManagedClustersUpdateTagsFuture, error) {
 	return clusterClient.UpdateTags(ctx, resourceGroupName, resourceName, parameters)
+}
+
+// UpdateCluster updates an existing managed Kubernetes cluster. Before updating, it pulls any existing configuration
+// and then only updates managed fields.
+func UpdateCluster(ctx context.Context, cred *Credentials, clusterClient services.ManagedClustersClientInterface, workplaceClient services.WorkplacesClientInterface,
+	spec *aksv1.AKSClusterConfigSpec, phase string) error {
+
+	// Create a new managed cluster from the AKS cluster config
+	managedCluster, err := createManagedCluster(ctx, cred, workplaceClient, spec, phase)
+	if err != nil {
+		return err
+	}
+
+	// Pull the upstream cluster state
+	aksCluster, err := clusterClient.Get(ctx, spec.ResourceGroup, spec.ClusterName)
+	if err != nil {
+		logrus.Errorf("Error getting upstream AKS cluster by name [%s]: %s", spec.ClusterName, err.Error())
+		return err
+	}
+
+	// Upstream cluster state was successfully pulled. Merge in updates without overwriting upstream fields: we never
+	// want to overwrite preconfigured values in Azure with nil values. So only update fields pulled from AKS with
+	// values from the managed cluster if they are non nil.
+
+	_, err = clusterClient.CreateOrUpdate(
+		ctx,
+		spec.ResourceGroup,
+		spec.ClusterName,
+		updateCluster(aksCluster, managedCluster),
+	)
+
+	return err
+}
+
+func updateCluster(aksCluster containerservice.ManagedCluster, managedCluster containerservice.ManagedCluster) containerservice.ManagedCluster {
+	/*
+		The following fields are managed in Rancher but are NOT configurable on update
+		- Name
+		- Location
+		- DNSPrefix
+		- EnablePrivateCluster
+		- LoadBalancerProfile
+	*/
+
+	if aksCluster.ManagedClusterProperties == nil {
+		aksCluster.ManagedClusterProperties = &containerservice.ManagedClusterProperties{}
+	}
+
+	// Update kubernetes version
+	// If a cluster is imported, we may not have the kubernetes version set on the spec.
+	if managedCluster.KubernetesVersion != nil {
+		aksCluster.KubernetesVersion = managedCluster.KubernetesVersion
+	}
+
+	// Add/update agent pool profiles
+	if aksCluster.AgentPoolProfiles == nil {
+		aksCluster.AgentPoolProfiles = &[]containerservice.ManagedClusterAgentPoolProfile{}
+	}
+
+	if managedCluster.AgentPoolProfiles != nil {
+		for _, ap := range *managedCluster.AgentPoolProfiles {
+			if !hasAgentPoolProfile(ap.Name, aksCluster.AgentPoolProfiles) {
+				*aksCluster.AgentPoolProfiles = append(*aksCluster.AgentPoolProfiles, ap)
+			}
+		}
+	}
+
+	// Add/update addon profiles (this will keep separate profiles added by AKS). This code will also add/update addon
+	// profiles for http application routing and monitoring.
+	if aksCluster.AddonProfiles == nil {
+		aksCluster.AddonProfiles = map[string]*containerservice.ManagedClusterAddonProfile{}
+	}
+	for profile := range managedCluster.AddonProfiles {
+		aksCluster.AddonProfiles[profile] = managedCluster.AddonProfiles[profile]
+	}
+
+	// Auth IP ranges
+	// note: there could be authorized IP ranges set in AKS that haven't propagated yet when this update is done. Add
+	// ranges from Rancher to any ones already set in AKS.
+	if aksCluster.APIServerAccessProfile == nil {
+		aksCluster.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{
+			AuthorizedIPRanges: &[]string{},
+		}
+	}
+
+	if managedCluster.APIServerAccessProfile != nil && managedCluster.APIServerAccessProfile.AuthorizedIPRanges != nil {
+
+		for index := range *managedCluster.APIServerAccessProfile.AuthorizedIPRanges {
+			ipRange := (*managedCluster.APIServerAccessProfile.AuthorizedIPRanges)[index]
+
+			if !hasAuthorizedIPRange(ipRange, aksCluster.APIServerAccessProfile.AuthorizedIPRanges) {
+				*aksCluster.APIServerAccessProfile.AuthorizedIPRanges = append(*aksCluster.APIServerAccessProfile.AuthorizedIPRanges, ipRange)
+			}
+		}
+	}
+
+	// Linux profile
+	if managedCluster.LinuxProfile != nil {
+		aksCluster.LinuxProfile = managedCluster.LinuxProfile
+	}
+
+	// Network profile
+	if managedCluster.NetworkProfile != nil {
+		np := managedCluster.NetworkProfile
+
+		if aksCluster.NetworkProfile == nil {
+			aksCluster.NetworkProfile = &containerservice.NetworkProfile{}
+		}
+
+		if np.NetworkPlugin != "" {
+			aksCluster.NetworkProfile.NetworkPlugin = np.NetworkPlugin
+		}
+		if np.NetworkPolicy != "" {
+			aksCluster.NetworkProfile.NetworkPolicy = np.NetworkPolicy
+		}
+		if np.NetworkMode != "" {
+			aksCluster.NetworkProfile.NetworkMode = np.NetworkMode
+		}
+		if np.DNSServiceIP != nil {
+			aksCluster.NetworkProfile.DNSServiceIP = np.DNSServiceIP
+		}
+		if np.DockerBridgeCidr != nil {
+			aksCluster.NetworkProfile.DockerBridgeCidr = np.DockerBridgeCidr
+		}
+		if np.PodCidr != nil {
+			aksCluster.NetworkProfile.PodCidr = np.PodCidr
+		}
+		if np.ServiceCidr != nil {
+			aksCluster.NetworkProfile.ServiceCidr = np.ServiceCidr
+		}
+		if np.OutboundType != "" {
+			aksCluster.NetworkProfile.OutboundType = np.OutboundType
+		}
+		if np.LoadBalancerSku != "" {
+			aksCluster.NetworkProfile.LoadBalancerSku = np.LoadBalancerSku
+		}
+		// LoadBalancerProfile is not configurable in Rancher so there won't be subfield conflicts. Just pull it from
+		// the state in AKS.
+	}
+
+	// Service principal client id and secret
+	if managedCluster.ServicePrincipalProfile != nil { // operator phase is 'updating' or 'active'
+		aksCluster.ServicePrincipalProfile = managedCluster.ServicePrincipalProfile
+	}
+
+	// Tags
+	if managedCluster.Tags != nil {
+		aksCluster.Tags = managedCluster.Tags
+	}
+
+	return aksCluster
 }

--- a/pkg/aks/update_test.go
+++ b/pkg/aks/update_test.go
@@ -1,0 +1,223 @@
+package aks
+
+import (
+	"errors"
+
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-11-01/containerservice"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/aks-operator/pkg/aks/services/mock_services"
+	aksv1 "github.com/rancher/aks-operator/pkg/apis/aks.cattle.io/v1"
+)
+
+var _ = Describe("updateCluster", func() {
+	var (
+		mockController       *gomock.Controller
+		workplacesClientMock *mock_services.MockWorkplacesClientInterface
+		clusterSpec          *aksv1.AKSClusterConfigSpec
+		cred                 *Credentials
+		actualCluster        *containerservice.ManagedCluster
+	)
+
+	BeforeEach(func() {
+		mockController = gomock.NewController(GinkgoT())
+		workplacesClientMock = mock_services.NewMockWorkplacesClientInterface(mockController)
+		clusterSpec = &aksv1.AKSClusterConfigSpec{
+			ResourceGroup:     "test-rg",
+			ClusterName:       "test-cluster",
+			KubernetesVersion: to.StringPtr("test-version"),
+			NodePools: []aksv1.AKSNodePool{
+				{
+					Name: to.StringPtr("test-nodepool"),
+				},
+			},
+			AuthorizedIPRanges:      to.StringSlicePtr([]string{"test-ip-range"}),
+			LinuxAdminUsername:      to.StringPtr("test-admin-username"),
+			LinuxSSHPublicKey:       to.StringPtr("test-ssh-public-key"),
+			NetworkPlugin:           to.StringPtr("azure"),
+			NetworkPolicy:           to.StringPtr("azure"),
+			NetworkDNSServiceIP:     to.StringPtr("test-dns-service-ip"),
+			NetworkDockerBridgeCIDR: to.StringPtr("test-docker-bridge-cidr"),
+			NetworkPodCIDR:          to.StringPtr("test-pod-cidr"),
+			NetworkServiceCIDR:      to.StringPtr("test-service-cidr"),
+			LoadBalancerSKU:         to.StringPtr("basic"),
+			Tags: map[string]string{
+				"test-tag": "test-value",
+			},
+		}
+		cred = &Credentials{
+			ClientID:     "test-client-id",
+			ClientSecret: "test-client-secret",
+		}
+		actualCluster = &containerservice.ManagedCluster{
+			ManagedClusterProperties: &containerservice.ManagedClusterProperties{
+				AddonProfiles: map[string]*containerservice.ManagedClusterAddonProfile{
+					"test-addon": {},
+				},
+			},
+		}
+	})
+
+	AfterEach(func() {
+		mockController.Finish()
+	})
+
+	It("should successfully update cluster", func() {
+		desiredCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "phase")
+		Expect(err).ToNot(HaveOccurred())
+
+		updatedCluster := updateCluster(desiredCluster, *actualCluster)
+		Expect(updatedCluster.KubernetesVersion).To(Equal(clusterSpec.KubernetesVersion))
+		Expect(updatedCluster.AddonProfiles).To(HaveKey("test-addon"))
+		Expect(updatedCluster.AddonProfiles).To(HaveKey("httpApplicationRouting"))
+		agentPoolProfiles := *updatedCluster.AgentPoolProfiles
+		Expect(agentPoolProfiles).To(HaveLen(1))
+		Expect(agentPoolProfiles[0].Name).To(Equal(clusterSpec.NodePools[0].Name))
+		Expect(agentPoolProfiles[0].OrchestratorVersion).To(Equal(clusterSpec.KubernetesVersion))
+		Expect(updatedCluster.APIServerAccessProfile).ToNot(BeNil())
+		authorizedIPranges := *updatedCluster.APIServerAccessProfile.AuthorizedIPRanges
+		Expect(authorizedIPranges).To(HaveLen(1))
+		Expect(authorizedIPranges[0]).To(Equal("test-ip-range"))
+		Expect(updatedCluster.LinuxProfile).ToNot(BeNil())
+		Expect(updatedCluster.LinuxProfile.AdminUsername).To(Equal(clusterSpec.LinuxAdminUsername))
+		sshPublicKeys := *updatedCluster.LinuxProfile.SSH.PublicKeys
+		Expect(sshPublicKeys).To(HaveLen(1))
+		Expect(sshPublicKeys[0].KeyData).To(Equal(clusterSpec.LinuxSSHPublicKey))
+		Expect(updatedCluster.NetworkProfile).ToNot(BeNil())
+		Expect(updatedCluster.NetworkProfile.NetworkPlugin).To(Equal(containerservice.Azure))
+		Expect(updatedCluster.NetworkProfile.NetworkPolicy).To(Equal(containerservice.NetworkPolicyAzure))
+		Expect(updatedCluster.NetworkProfile.DNSServiceIP).To(Equal(clusterSpec.NetworkDNSServiceIP))
+		Expect(updatedCluster.NetworkProfile.DockerBridgeCidr).To(Equal(clusterSpec.NetworkDockerBridgeCIDR))
+		Expect(updatedCluster.NetworkProfile.PodCidr).To(Equal(clusterSpec.NetworkPodCIDR))
+		Expect(updatedCluster.NetworkProfile.ServiceCidr).To(Equal(clusterSpec.NetworkServiceCIDR))
+		Expect(updatedCluster.NetworkProfile.LoadBalancerSku).To(Equal(containerservice.Basic))
+		Expect(updatedCluster.ServicePrincipalProfile).ToNot(BeNil())
+		Expect(updatedCluster.ServicePrincipalProfile.ClientID).To(Equal(to.StringPtr(cred.ClientID)))
+		Expect(updatedCluster.ServicePrincipalProfile.Secret).To(Equal(to.StringPtr(cred.ClientSecret)))
+		Expect(updatedCluster.Tags).To(HaveKeyWithValue("test-tag", to.StringPtr("test-value")))
+	})
+
+	It("shouldn't update kubernetes version if it's not specified", func() {
+		clusterSpec.KubernetesVersion = nil
+		desiredCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "phase")
+		Expect(err).ToNot(HaveOccurred())
+
+		updatedCluster := updateCluster(desiredCluster, *actualCluster)
+		Expect(updatedCluster.KubernetesVersion).To(BeNil())
+	})
+
+	It("shouldn't add new agent pool profile if it already exists", func() {
+		actualCluster.AgentPoolProfiles = &[]containerservice.ManagedClusterAgentPoolProfile{
+			{
+				Name: to.StringPtr("test-nodepool"),
+			},
+		}
+		desiredCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "phase")
+		Expect(err).ToNot(HaveOccurred())
+
+		updatedCluster := updateCluster(desiredCluster, *actualCluster)
+		agentPoolProfiles := *updatedCluster.AgentPoolProfiles
+		Expect(agentPoolProfiles).To(HaveLen(1))
+	})
+
+	It("shouldn't set authorized IP ranges if not specified in cluster spec", func() {
+		clusterSpec.AuthorizedIPRanges = nil
+		desiredCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "phase")
+		Expect(err).ToNot(HaveOccurred())
+
+		updatedCluster := updateCluster(desiredCluster, *actualCluster)
+		Expect(updatedCluster.APIServerAccessProfile).ToNot(BeNil())
+		Expect(updatedCluster.APIServerAccessProfile.AuthorizedIPRanges).ToNot(BeNil())
+		authorizedIPranges := *updatedCluster.APIServerAccessProfile.AuthorizedIPRanges
+		Expect(authorizedIPranges).To(HaveLen(0))
+	})
+
+	It("shoudn't add new authorized IP range if it already exists ", func() {
+		actualCluster.APIServerAccessProfile = &containerservice.ManagedClusterAPIServerAccessProfile{
+			AuthorizedIPRanges: &[]string{"test-ip-range"},
+		}
+		desiredCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "phase")
+		Expect(err).ToNot(HaveOccurred())
+
+		updatedCluster := updateCluster(desiredCluster, *actualCluster)
+		Expect(updatedCluster.APIServerAccessProfile.AuthorizedIPRanges).To(Equal(actualCluster.APIServerAccessProfile.AuthorizedIPRanges))
+		Expect(updatedCluster.APIServerAccessProfile).ToNot(BeNil())
+		authorizedIPranges := *updatedCluster.APIServerAccessProfile.AuthorizedIPRanges
+		Expect(authorizedIPranges).To(HaveLen(1))
+		Expect(authorizedIPranges[0]).To(Equal("test-ip-range"))
+	})
+
+	It("shouldn't update linux profile if it's not specified", func() {
+		clusterSpec.LinuxAdminUsername = nil
+		clusterSpec.LinuxSSHPublicKey = nil
+		desiredCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "phase")
+		Expect(err).ToNot(HaveOccurred())
+
+		updatedCluster := updateCluster(desiredCluster, *actualCluster)
+		Expect(updatedCluster.LinuxProfile).To(BeNil())
+	})
+
+	It("shouldn't update service principal if phase is active or updating", func() {
+		desiredCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "active")
+		Expect(err).ToNot(HaveOccurred())
+
+		updatedCluster := updateCluster(desiredCluster, *actualCluster)
+		Expect(updatedCluster.ServicePrincipalProfile).To(BeNil())
+	})
+
+	It("shouldn't update tags if not specified in cluster spec", func() {
+		clusterSpec.Tags = nil
+		desiredCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "phase")
+		Expect(err).ToNot(HaveOccurred())
+
+		updatedCluster := updateCluster(desiredCluster, *actualCluster)
+		Expect(updatedCluster.Tags).To(HaveLen(0))
+	})
+})
+
+var _ = Describe("UpdateCluster", func() {
+	var (
+		mockController       *gomock.Controller
+		workplacesClientMock *mock_services.MockWorkplacesClientInterface
+		clusterClientMock    *mock_services.MockManagedClustersClientInterface
+		clusterSpec          *aksv1.AKSClusterConfigSpec
+	)
+
+	BeforeEach(func() {
+		mockController = gomock.NewController(GinkgoT())
+		workplacesClientMock = mock_services.NewMockWorkplacesClientInterface(mockController)
+		clusterClientMock = mock_services.NewMockManagedClustersClientInterface(mockController)
+		clusterSpec = &aksv1.AKSClusterConfigSpec{
+			ResourceGroup: "test-rg",
+			ClusterName:   "test-cluster",
+		}
+	})
+
+	AfterEach(func() {
+		mockController.Finish()
+	})
+
+	It("should successfully update cluster", func() {
+		clusterClientMock.EXPECT().Get(ctx, clusterSpec.ResourceGroup, clusterSpec.ClusterName).Return(containerservice.ManagedCluster{}, nil)
+		clusterClientMock.EXPECT().CreateOrUpdate(ctx, clusterSpec.ResourceGroup, clusterSpec.ClusterName, gomock.Any()).Return(containerservice.ManagedClustersCreateOrUpdateFuture{}, nil)
+		Expect(UpdateCluster(ctx, &Credentials{}, clusterClientMock, workplacesClientMock, clusterSpec, "active")).To(Succeed())
+	})
+
+	It("should fail when createManagedCluster returns error", func() {
+		clusterSpec.Monitoring = to.BoolPtr(true)
+		Expect(UpdateCluster(ctx, &Credentials{}, clusterClientMock, workplacesClientMock, clusterSpec, "active")).ToNot(Succeed())
+	})
+
+	It("should fail when azure API returns error on Get() request", func() {
+		clusterClientMock.EXPECT().Get(ctx, clusterSpec.ResourceGroup, clusterSpec.ClusterName).Return(containerservice.ManagedCluster{}, errors.New("test error"))
+		Expect(UpdateCluster(ctx, &Credentials{}, clusterClientMock, workplacesClientMock, clusterSpec, "active")).ToNot(Succeed())
+	})
+
+	It("should fail when azure API returns error on CreateOrUpdate() request", func() {
+		clusterClientMock.EXPECT().Get(ctx, clusterSpec.ResourceGroup, clusterSpec.ClusterName).Return(containerservice.ManagedCluster{}, nil)
+		clusterClientMock.EXPECT().CreateOrUpdate(ctx, clusterSpec.ResourceGroup, clusterSpec.ClusterName, gomock.Any()).Return(containerservice.ManagedClustersCreateOrUpdateFuture{}, errors.New("test error"))
+		Expect(UpdateCluster(ctx, &Credentials{}, clusterClientMock, workplacesClientMock, clusterSpec, "active")).ToNot(Succeed())
+	})
+})


### PR DESCRIPTION
This PR adds more unit tests for azure services. There are no logical changes in cluster create/update actions.