### PR TITLE
[2.6] Pass node pool's subnet id to azure client

### DIFF
--- a/charts/aks-operator-crd/templates/crds.yaml
+++ b/charts/aks-operator-crd/templates/crds.yaml
@@ -122,6 +122,9 @@ spec:
                     vmSize:
                       nullable: true
                       type: string
+                    vnetSubnetID:
+                      nullable: true
+                      type: string
                   type: object
                 nullable: true
                 type: array

--- a/controller/aks-cluster-config-handler.go
+++ b/controller/aks-cluster-config-handler.go
@@ -659,6 +659,7 @@ func BuildUpstreamClusterState(ctx context.Context, secretsCache wranglerv1.Secr
 			upstreamNP.MaxCount = np.MaxCount
 			upstreamNP.MinCount = np.MinCount
 		}
+		upstreamNP.VnetSubnetID = np.VnetSubnetID
 		upstreamSpec.NodePools = append(upstreamSpec.NodePools, upstreamNP)
 	}
 
@@ -861,6 +862,10 @@ func (h *Handler) updateUpstreamClusterState(ctx context.Context, secretsCache w
 			updateNodePool := false
 			upstreamNodePool, ok := upstreamNodePools[npName]
 			if ok {
+				if upstreamNodePool.VnetSubnetID != nil {
+					np.VnetSubnetID = upstreamNodePool.VnetSubnetID
+				}
+
 				if to.Bool(np.EnableAutoScaling) {
 					// Count can't be updated when EnableAutoScaling is true, so don't send anything.
 					np.Count = nil

--- a/pkg/aks/create.go
+++ b/pkg/aks/create.go
@@ -355,6 +355,7 @@ func CreateOrUpdateAgentPool(ctx context.Context, agentPoolClient *containerserv
 		EnableAutoScaling:   np.EnableAutoScaling,
 		MinCount:            np.MinCount,
 		MaxCount:            np.MaxCount,
+		VnetSubnetID:        np.VnetSubnetID,
 	}
 
 	_, err := agentPoolClient.CreateOrUpdate(ctx, spec.ResourceGroup, spec.ClusterName, to.String(np.Name), containerservice.AgentPool{

--- a/pkg/aks/create.go
+++ b/pkg/aks/create.go
@@ -90,6 +90,9 @@ func UpdateCluster(ctx context.Context, cred *Credentials, clusterClient *contai
 
 	// Add/update addon profiles (this will keep separate profiles added by AKS). This code will also add/update addon
 	// profiles for http application routing and monitoring.
+	if aksCluster.AddonProfiles == nil {
+		aksCluster.AddonProfiles = map[string]*containerservice.ManagedClusterAddonProfile{}
+	}
 	for profile := range managedCluster.AddonProfiles {
 		aksCluster.AddonProfiles[profile] = managedCluster.AddonProfiles[profile]
 	}

--- a/pkg/apis/aks.cattle.io/v1/types.go
+++ b/pkg/apis/aks.cattle.io/v1/types.go
@@ -84,4 +84,5 @@ type AKSNodePool struct {
 	MaxCount            *int32    `json:"maxCount,omitempty"`
 	MinCount            *int32    `json:"minCount,omitempty"`
 	EnableAutoScaling   *bool     `json:"enableAutoScaling,omitempty"`
+	VnetSubnetID        *string   `json:"vnetSubnetID,omitempty" norman:"pointer"`
 }

--- a/pkg/apis/aks.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/aks.cattle.io/v1/zz_generated_deepcopy.go
@@ -303,6 +303,11 @@ func (in *AKSNodePool) DeepCopyInto(out *AKSNodePool) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.VnetSubnetID != nil {
+		in, out := &in.VnetSubnetID, &out.VnetSubnetID
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
Backport of:
- https://github.com/rancher/aks-operator/pull/76
- https://github.com/rancher/aks-operator/pull/77

Fixes for https://github.com/rancher/rancher/issues/40087 needed by Rancher v2.6