### PR TITLE
Fix Rancher integration

### DIFF
--- a/controller/aks-cluster-config-handler.go
+++ b/controller/aks-cluster-config-handler.go
@@ -344,7 +344,7 @@ func (h *Handler) checkAndUpdate(config *aksv1.AKSClusterConfig) (*aksv1.AKSClus
 	}
 
 	logrus.Infof("Checking configuration for cluster [%s]", config.Spec.ClusterName)
-	upstreamSpec, err := h.buildUpstreamClusterState(ctx, &config.Spec)
+	upstreamSpec, err := h.BuildUpstreamClusterState(ctx, &config.Spec)
 	if err != nil {
 		return config, err
 	}
@@ -510,7 +510,7 @@ func (h *Handler) enqueueUpdate(config *aksv1.AKSClusterConfig) (*aksv1.AKSClust
 // createCASecret creates a secret containing ca and endpoint. These can be used to create a kubeconfig via
 // the go sdk
 func (h *Handler) createCASecret(ctx context.Context, config *aksv1.AKSClusterConfig) error {
-	kubeConfig, err := h.getClusterKubeConfig(ctx, &config.Spec)
+	kubeConfig, err := h.GetClusterKubeConfig(ctx, &config.Spec)
 	if err != nil {
 		return err
 	}
@@ -539,7 +539,7 @@ func (h *Handler) createCASecret(ctx context.Context, config *aksv1.AKSClusterCo
 	return err
 }
 
-func (h *Handler) getClusterKubeConfig(ctx context.Context, spec *aksv1.AKSClusterConfigSpec) (restConfig *rest.Config, err error) {
+func (h *Handler) GetClusterKubeConfig(ctx context.Context, spec *aksv1.AKSClusterConfigSpec) (restConfig *rest.Config, err error) {
 	accessProfile, err := h.azureClients.clustersClient.GetAccessProfile(ctx, spec.ResourceGroup, spec.ClusterName, "clusterAdmin")
 	if err != nil {
 		return nil, err
@@ -554,7 +554,7 @@ func (h *Handler) getClusterKubeConfig(ctx context.Context, spec *aksv1.AKSClust
 
 // buildUpstreamClusterState creates an AKSClusterConfigSpec (spec for the AKS cluster state) from the existing
 // cluster configuration.
-func (h *Handler) buildUpstreamClusterState(ctx context.Context, spec *aksv1.AKSClusterConfigSpec) (*aksv1.AKSClusterConfigSpec, error) {
+func (h *Handler) BuildUpstreamClusterState(ctx context.Context, spec *aksv1.AKSClusterConfigSpec) (*aksv1.AKSClusterConfigSpec, error) {
 	upstreamSpec := &aksv1.AKSClusterConfigSpec{}
 
 	clusterState, err := h.azureClients.clustersClient.Get(ctx, spec.ResourceGroup, spec.ClusterName)

--- a/pkg/aks/check.go
+++ b/pkg/aks/check.go
@@ -113,7 +113,7 @@ var regionToOmsRegionMap = map[string]string{
 	"chinanorth2": "chinaeast2",
 }
 
-func checkLogAnalyticsWorkspaceForMonitoring(ctx context.Context, client services.WorkplacesClientInterface,
+func CheckLogAnalyticsWorkspaceForMonitoring(ctx context.Context, client services.WorkplacesClientInterface,
 	location string, group string, wsg string, wsn string) (workspaceID string, err error) {
 
 	workspaceRegion, ok := regionToOmsRegionMap[location]

--- a/pkg/aks/check_test.go
+++ b/pkg/aks/check_test.go
@@ -32,7 +32,7 @@ func Test_generateUniqueLogWorkspace(t *testing.T) {
 	}
 }
 
-var _ = Describe("checkLogAnalyticsWorkspaceForMonitoring", func() {
+var _ = Describe("CheckLogAnalyticsWorkspaceForMonitoring", func() {
 	var (
 		workplacesClientMock *mock_services.MockWorkplacesClientInterface
 		mockController       *gomock.Controller
@@ -54,7 +54,7 @@ var _ = Describe("checkLogAnalyticsWorkspaceForMonitoring", func() {
 		workplacesClientMock.EXPECT().Get(ctx, workspaceResourceGroup, workspaceName).Return(operationalinsights.Workspace{
 			ID: &id,
 		}, nil)
-		workspaceID, err := checkLogAnalyticsWorkspaceForMonitoring(ctx,
+		workspaceID, err := CheckLogAnalyticsWorkspaceForMonitoring(ctx,
 			workplacesClientMock,
 			"eastus", workspaceResourceGroup, "", workspaceName)
 		Expect(err).NotTo(HaveOccurred())
@@ -80,7 +80,7 @@ var _ = Describe("checkLogAnalyticsWorkspaceForMonitoring", func() {
 			ID: &id,
 		}, nil)
 
-		workspaceID, err := checkLogAnalyticsWorkspaceForMonitoring(ctx,
+		workspaceID, err := CheckLogAnalyticsWorkspaceForMonitoring(ctx,
 			workplacesClientMock,
 			"eastus", workspaceResourceGroup, "", workspaceName)
 
@@ -92,7 +92,7 @@ var _ = Describe("checkLogAnalyticsWorkspaceForMonitoring", func() {
 		workplacesClientMock.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(operationalinsights.Workspace{}, errors.New("not found"))
 		workplacesClientMock.EXPECT().CreateOrUpdate(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(operationalinsights.WorkspacesCreateOrUpdateFuture{}, errors.New("error"))
 
-		_, err := checkLogAnalyticsWorkspaceForMonitoring(ctx,
+		_, err := CheckLogAnalyticsWorkspaceForMonitoring(ctx,
 			workplacesClientMock,
 			"eastus", "workspaceResourceGroup", "", "workspaceName")
 
@@ -104,7 +104,7 @@ var _ = Describe("checkLogAnalyticsWorkspaceForMonitoring", func() {
 		workplacesClientMock.EXPECT().CreateOrUpdate(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(operationalinsights.WorkspacesCreateOrUpdateFuture{}, nil)
 		workplacesClientMock.EXPECT().AsyncCreateUpdateResult(gomock.Any()).Return(operationalinsights.Workspace{}, errors.New("error"))
 
-		_, err := checkLogAnalyticsWorkspaceForMonitoring(ctx,
+		_, err := CheckLogAnalyticsWorkspaceForMonitoring(ctx,
 			workplacesClientMock,
 			"eastus", "workspaceResourceGroup", "", "workspaceName")
 

--- a/pkg/aks/client.go
+++ b/pkg/aks/client.go
@@ -92,7 +92,7 @@ func GetSecrets(secretsCache wranglerv1.SecretCache, secretClient wranglerv1.Sec
 	cred.BaseURL = spec.BaseURL
 
 	if cred.TenantID == "" {
-		cred.TenantID, err = getCachedTenantID(secretClient, cred.SubscriptionID, secret)
+		cred.TenantID, err = GetCachedTenantID(secretClient, cred.SubscriptionID, secret)
 		if err != nil {
 			return nil, err
 		}
@@ -105,7 +105,7 @@ type secretClient interface {
 	Update(*v1.Secret) (*v1.Secret, error)
 }
 
-func getCachedTenantID(secretClient secretClient, subscriptionID string, secret *v1.Secret) (string, error) {
+func GetCachedTenantID(secretClient secretClient, subscriptionID string, secret *v1.Secret) (string, error) {
 	annotations := secret.GetAnnotations()
 	tenantAnno, timestamp := annotations[tenantIDAnnotation], annotations[tenantIDTimestampAnnotation]
 	if tenantAnno != "" && timestamp != "" {

--- a/pkg/aks/create.go
+++ b/pkg/aks/create.go
@@ -156,7 +156,7 @@ func createManagedCluster(ctx context.Context, cred *Credentials, workplacesClie
 			Enabled: spec.Monitoring,
 		}
 
-		logAnalyticsWorkspaceResourceID, err := checkLogAnalyticsWorkspaceForMonitoring(ctx, workplacesClient,
+		logAnalyticsWorkspaceResourceID, err := CheckLogAnalyticsWorkspaceForMonitoring(ctx, workplacesClient,
 			spec.ResourceLocation, spec.ResourceGroup, to.String(spec.LogAnalyticsWorkspaceGroup), to.String(spec.LogAnalyticsWorkspaceName))
 		if err != nil {
 			return managedCluster, err


### PR DESCRIPTION
Module aks-operator is imported by Rancher and functions:
- BuildUpstreamClusterState
https://github.com/rancher/rancher/blob/release/v2.7/pkg/controllers/management/clusterupstreamrefresher/aks_upstream_spec.go#L14

- GetCachedTenantID
https://github.com/rancher/rancher/blob/release/v2.7/pkg/api/norman/customization/aks/handler.go#L247

- GetClusterKubeConfig
https://github.com/rancher/rancher/blob/release/v2.7/pkg/controllers/management/aks/aks_cluster_handler.go#L442

- CheckLogAnalyticsWorkspaceForMonitoring
https://github.com/rancher/rancher/blob/release/v2.7/pkg/kontainer-engine/drivers/aks/aks_driver.go#L718

have to be public, because they are used by Rancher.


Signed-off-by: Michal Jura <mjura@suse.com>