### PR TITLE
Make Azure services compliant with Rancher

### DIFF
--- a/pkg/aks/client.go
+++ b/pkg/aks/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-11-01/containerservice"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -134,4 +135,16 @@ func GetCachedTenantID(secretClient secretClient, subscriptionID string, secret 
 		return tenantID, nil
 	}
 	return tenantID, err
+}
+
+func NewClusterClient(cred *Credentials) (*containerservice.ManagedClustersClient, error) {
+	authorizer, err := NewClientAuthorizer(cred)
+	if err != nil {
+		return nil, err
+	}
+
+	client := containerservice.NewManagedClustersClientWithBaseURI(to.String(cred.BaseURL), cred.SubscriptionID)
+	client.Authorizer = authorizer
+
+	return &client, nil
 }


### PR DESCRIPTION
For future implementation:
- change `BuildUpstreamClusterState` function definition and pass cluster client object instead of passing secrets and creating cluster client inside of it
- adjust Rancher integration  in https://github.com/rancher/rancher/blob/release/v2.7/pkg/controllers/management/clusterupstreamrefresher/aks_upstream_spec.go#L14 and use new function definition
