### PR TITLE
Automate operator version bump in rancher

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
   schedule:
     interval: "weekly"
   ignore:
+  - dependency-name: "sigs.k8s.io/controller-runtime"
   # Ignore k8s and its transitives modules as they are upgraded manually
   # together with controller-runtime.
   - dependency-name: "k8s.io/*"

--- a/.github/workflows/update-rancher-dep.yaml
+++ b/.github/workflows/update-rancher-dep.yaml
@@ -1,0 +1,38 @@
+---
+name: "Update AKS Operator version in Rancher" 
+
+on:
+  workflow_dispatch:
+    inputs:
+      rancher-branch:
+        description: Rancher branch
+        required: true
+        default: release/v2.7
+      aks-operator-tag:
+        description: AKS Operator release tag
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.x
+      - name: Install Updatecli in the runner
+        uses: updatecli/updatecli-action@v2
+      - name: Update aks operator dependency in rancher
+        run: "updatecli apply --config ./.updatecli/updatecli.d/bump-rancher-dep.yaml"
+        env:
+          UPDATECLI_GITHUB_ACTOR: ${{ github.actor }}
+          UPDATECLI_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATECLI_RANCHER_BRANCH: ${{ github.event.inputs.rancher-branch }}
+          UPDATECLI_AKS_OPERATOR_TAG: ${{ github.event.inputs.aks-operator-tag }}

--- a/.updatecli/updatecli.d/bump-rancher-dep.yaml
+++ b/.updatecli/updatecli.d/bump-rancher-dep.yaml
@@ -1,0 +1,138 @@
+name: 'Bump AKS operator'
+
+scms:
+  rancher:
+    kind: github
+    spec:
+      user: aks-operator-bot
+      email: aks-operator@bot.com
+      owner: rancher
+      repository: rancher
+      branch: '{{ requiredEnv "UPDATECLI_RANCHER_BRANCH" }}'
+      token: '{{ requiredEnv "UPDATECLI_GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "UPDATECLI_GITHUB_ACTOR" }}'
+
+sources:
+  rancher-repo:
+    name: Update go.mod and pkg/apis/go.mod in rancher
+    kind: shell
+    spec:
+      environments:
+        - name: PATH
+        - name: rancher_branch
+          value: '{{ requiredEnv "UPDATECLI_RANCHER_BRANCH" }}'
+      command: |
+        tmp_dir="$(mktemp -d)"
+        cd "${tmp_dir}"
+        git clone https://github.com/rancher/rancher.git . >&2
+        git checkout ${rancher_branch} >&2
+        printf ${tmp_dir}
+        exit 0
+    scmid: rancher
+  bump-rancher-deps:
+    dependson:
+      - rancher-repo
+    name: Update go.mod and pkg/apis/go.mod in rancher
+    kind: shell
+    spec:
+      environments:
+        - name: operator_version
+          value: '{{ requiredEnv "UPDATECLI_AKS_OPERATOR_TAG" }}'
+        - name: PATH
+      command: |
+        cd "{{ source "rancher-repo" }}"
+        GOPATH="$(mktemp -d)"
+        export GOPATH
+        go get "github.com/rancher/aks-operator@${operator_version}"
+        go mod tidy
+        cd pkg/apis
+        go get "github.com/rancher/aks-operator@${operator_version}"
+        go mod tidy
+        echo "Success"
+        exit 0
+    scmid: rancher
+  rancher-gomod:
+    dependson:
+      - bump-rancher-deps
+    name: Print go.mod
+    kind: shell
+    spec:
+      command: |
+        cd "{{ source "rancher-repo" }}"
+        echo "" >> go.mod
+        cat go.mod
+    scmid: rancher
+  rancher-gosum:
+    dependson:
+      - bump-rancher-deps
+    name: Print go.sum
+    kind: shell
+    spec:
+      command: |
+        cd "{{ source "rancher-repo" }}"
+        echo "" >> go.sum
+        cat go.sum
+    scmid: rancher
+  rancher-apis-gomod:
+    dependson:
+      - bump-rancher-deps
+    name: Print go.mod in pkg/apis
+    kind: shell
+    spec:
+      command: |
+        cd "{{ source "rancher-repo" }}"
+        echo "" >> pkg/apis/go.mod
+        cat pkg/apis/go.mod
+    scmid: rancher
+  rancher-apis-gosum:
+    dependson:
+      - bump-rancher-deps
+    name: Print go.sum in pkg/apis
+    kind: shell
+    spec:
+      command: |
+        cd "{{ source "rancher-repo" }}"
+        echo "" >> pkg/apis/go.sum
+        cat pkg/apis/go.sum
+    scmid: rancher
+
+targets:
+    rancher-gomod:
+        name: Update AKS operator version to "{{ requiredEnv "UPDATECLI_AKS_OPERATOR_TAG" }}" in go.mod
+        kind: file
+        spec:
+          file: go.mod
+        scmid: rancher
+        sourceid: rancher-gomod
+    rancher-gosum:
+        name: Update AKS operator version to "{{ requiredEnv "UPDATECLI_AKS_OPERATOR_TAG" }}" in go.sum
+        kind: file
+        spec:
+          file: go.sum
+        scmid: rancher
+        sourceid: rancher-gosum
+    rancher-apis-gomod:
+        name: Update AKS operator version to "{{ requiredEnv "UPDATECLI_AKS_OPERATOR_TAG" }}" in pkg/apis/go.mod
+        kind: file
+        spec:
+          file: pkg/apis/go.mod
+        scmid: rancher
+        sourceid: rancher-apis-gomod
+    rancher-apis-gosum:
+        name: Update AKS operator version to "{{ requiredEnv "UPDATECLI_AKS_OPERATOR_TAG" }}" in pkg/apis/go.mod
+        kind: file
+        spec:
+          file: pkg/apis/go.sum
+        scmid: rancher
+        sourceid: rancher-apis-gosum
+
+actions:
+  update-aks-operator:
+    kind: github/pullrequest
+    scmid: rancher
+    title: 'Bump AKS operator version to new version {{ requiredEnv "UPDATECLI_AKS_OPERATOR_TAG" }}'
+    spec:
+      automerge: false
+      mergemethod: squash
+      description: "@alexander-demicev @mjura @richardcase"
+


### PR DESCRIPTION
Introduce a GitHub action that uses https://www.updatecli.io/ to automatically bump aks version in rancher when needed. The action should be run manually from GitHub actions tab.