### PR TITLE
Assign TenantID to managed cluster identity

### DIFF
--- a/pkg/aks/create.go
+++ b/pkg/aks/create.go
@@ -266,6 +266,13 @@ func createManagedCluster(ctx context.Context, cred *Credentials, workplacesClie
 		managedCluster.APIServerAccessProfile.EnablePrivateCluster = spec.PrivateCluster
 	}
 
+	if cred.TenantID != "" {
+		managedCluster.Identity = &containerservice.ManagedClusterIdentity{
+			TenantID: to.StringPtr(cred.TenantID),
+			Type:     containerservice.ResourceIdentityTypeSystemAssigned,
+		}
+	}
+
 	return managedCluster, nil
 }
 


### PR DESCRIPTION
This is helpful when the Service Principal and the Resource group do not belong in the same Tenant.

Before this change trying to do so would give error showing that the ClientID was not found under TenantID of the Resource group.