### PR TITLE
Use envtest for testing controller package

### DIFF
--- a/controller/aks-cluster-config-handler.go
+++ b/controller/aks-cluster-config-handler.go
@@ -510,7 +510,7 @@ func (h *Handler) enqueueUpdate(config *aksv1.AKSClusterConfig) (*aksv1.AKSClust
 // createCASecret creates a secret containing ca and endpoint. These can be used to create a kubeconfig via
 // the go sdk
 func (h *Handler) createCASecret(ctx context.Context, config *aksv1.AKSClusterConfig) error {
-	kubeConfig, err := GetClusterKubeConfig(ctx, h.secretsCache, h.secrets, &config.Spec)
+	kubeConfig, err := h.getClusterKubeConfig(ctx, &config.Spec)
 	if err != nil {
 		return err
 	}
@@ -539,16 +539,8 @@ func (h *Handler) createCASecret(ctx context.Context, config *aksv1.AKSClusterCo
 	return err
 }
 
-func GetClusterKubeConfig(ctx context.Context, secretsCache wranglerv1.SecretCache, secretClient wranglerv1.SecretClient, spec *aksv1.AKSClusterConfigSpec) (restConfig *rest.Config, err error) {
-	credentials, err := aks.GetSecrets(secretsCache, secretClient, spec)
-	if err != nil {
-		return nil, err
-	}
-	resourceClusterClient, err := aks.NewClusterClient(credentials)
-	if err != nil {
-		return nil, err
-	}
-	accessProfile, err := resourceClusterClient.GetAccessProfile(ctx, spec.ResourceGroup, spec.ClusterName, "clusterAdmin")
+func (h *Handler) getClusterKubeConfig(ctx context.Context, spec *aksv1.AKSClusterConfigSpec) (restConfig *rest.Config, err error) {
+	accessProfile, err := h.azureClients.clustersClient.GetAccessProfile(ctx, spec.ResourceGroup, spec.ClusterName, "clusterAdmin")
 	if err != nil {
 		return nil, err
 	}

--- a/controller/aks-cluster-config-handler_test.go
+++ b/controller/aks-cluster-config-handler_test.go
@@ -1,0 +1,117 @@
+package controller
+
+import (
+	"errors"
+
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-11-01/containerservice"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/aks-operator/pkg/aks/services/mock_services"
+	aksv1 "github.com/rancher/aks-operator/pkg/apis/aks.cattle.io/v1"
+	"github.com/rancher/aks-operator/pkg/test"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("importCluster", func() {
+	var (
+		handler           *Handler
+		mockController    *gomock.Controller
+		aksConfig         *aksv1.AKSClusterConfig
+		clusterClientMock *mock_services.MockManagedClustersClientInterface
+		caSecret          *corev1.Secret
+	)
+
+	BeforeEach(func() {
+		mockController = gomock.NewController(GinkgoT())
+		clusterClientMock = mock_services.NewMockManagedClustersClientInterface(mockController)
+
+		aksConfig = &aksv1.AKSClusterConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+			},
+			Spec: aksv1.AKSClusterConfigSpec{
+				ResourceGroup: "test",
+				ClusterName:   "test",
+			},
+		}
+
+		Expect(cl.Create(ctx, aksConfig)).To(Succeed())
+
+		caSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      aksConfig.Name,
+				Namespace: aksConfig.Namespace,
+			},
+		}
+
+		handler = &Handler{
+			aksCC:        aksFactory.Aks().V1().AKSClusterConfig(),
+			secrets:      coreFactory.Core().V1().Secret(),
+			secretsCache: coreFactory.Core().V1().Secret().Cache(),
+			azureClients: azureClients{
+				clustersClient: clusterClientMock,
+			},
+		}
+	})
+
+	AfterEach(func() {
+		Expect(test.CleanupAndWait(ctx, cl, caSecret, aksConfig)).To(Succeed())
+	})
+
+	It("should create CA secret and update status", func() {
+		kubeconfigYAML := `
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCnRlc3QKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+    server: https://test.com
+  name: test
+contexts:
+- context:
+    cluster: test
+    user: test
+  name: test
+current-context: test
+kind: Config
+preferences: {}
+users:
+- name: test
+  user:
+    client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCnRlc3QKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+    client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQp0ZXN0Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
+    token: dGVzdA==`
+
+		clusterClientMock.EXPECT().GetAccessProfile(gomock.Any(), aksConfig.Spec.ResourceGroup, aksConfig.Spec.ClusterName, "clusterAdmin").
+			Return(containerservice.ManagedClusterAccessProfile{
+				AccessProfile: &containerservice.AccessProfile{
+					KubeConfig: to.ByteSlicePtr([]byte(kubeconfigYAML)),
+				},
+			}, nil)
+
+		gotAKSConfig, err := handler.importCluster(aksConfig)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(gotAKSConfig.Status.Phase).To(Equal(aksConfigActivePhase))
+
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(caSecret), caSecret)).To(Succeed())
+		Expect(caSecret.OwnerReferences).To(HaveLen(1))
+		Expect(caSecret.OwnerReferences[0].Name).To(Equal(gotAKSConfig.Name))
+		Expect(caSecret.OwnerReferences[0].UID).To(Equal(gotAKSConfig.UID))
+		Expect(caSecret.OwnerReferences[0].Kind).To(Equal(aksClusterConfigKind))
+		Expect(caSecret.OwnerReferences[0].APIVersion).To(Equal(aksv1.SchemeGroupVersion.String()))
+		Expect(caSecret.Data["endpoint"]).To(Equal([]byte("https://test.com")))
+		Expect(caSecret.Data["ca"]).To(Equal([]byte("LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCnRlc3QKLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=")))
+	})
+
+	It("should return error if something fails", func() {
+		clusterClientMock.EXPECT().GetAccessProfile(gomock.Any(), aksConfig.Spec.ResourceGroup, aksConfig.Spec.ClusterName, "clusterAdmin").
+			Return(containerservice.ManagedClusterAccessProfile{}, errors.New("error"))
+
+		_, err := handler.importCluster(aksConfig)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/controller/external.go
+++ b/controller/external.go
@@ -1,0 +1,33 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/rancher/aks-operator/pkg/aks"
+	aksv1 "github.com/rancher/aks-operator/pkg/apis/aks.cattle.io/v1"
+	wranglerv1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// GetClusterKubeConfig returns a kubeconfig for a given cluster. This function is imported in rancher/rancher and has to stay for compatibility.
+func GetClusterKubeConfig(ctx context.Context, secretsCache wranglerv1.SecretCache, secretClient wranglerv1.SecretClient, spec *aksv1.AKSClusterConfigSpec) (restConfig *rest.Config, err error) {
+	credentials, err := aks.GetSecrets(secretsCache, secretClient, spec)
+	if err != nil {
+		return nil, err
+	}
+	resourceClusterClient, err := aks.NewClusterClient(credentials)
+	if err != nil {
+		return nil, err
+	}
+	accessProfile, err := resourceClusterClient.GetAccessProfile(ctx, spec.ResourceGroup, spec.ClusterName, "clusterAdmin")
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := clientcmd.RESTConfigFromKubeConfig(*accessProfile.KubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	return config, nil
+}

--- a/controller/suite_test.go
+++ b/controller/suite_test.go
@@ -1,0 +1,57 @@
+package controller
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	aksv1 "github.com/rancher/aks-operator/pkg/generated/controllers/aks.cattle.io"
+	"github.com/rancher/aks-operator/pkg/test"
+	"github.com/rancher/wrangler/pkg/generated/controllers/core"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	testEnv     *envtest.Environment
+	cfg         *rest.Config
+	cl          client.Client
+	coreFactory *core.Factory
+	aksFactory  *aksv1.Factory
+
+	ctx = context.Background()
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AKS Operator Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	By("bootstrapping test environment")
+	var err error
+	testEnv = &envtest.Environment{}
+	cfg, cl, err = test.StartEnvTest(testEnv)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+	Expect(cl).NotTo(BeNil())
+
+	coreFactory, err = core.NewFactoryFromConfig(cfg)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(coreFactory).NotTo(BeNil())
+
+	aksFactory, err = aksv1.NewFactoryFromConfig(cfg)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(aksFactory).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	Expect(test.StopEnvTest(testEnv)).To(Succeed())
+})

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 
 require (
 	github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46
+	github.com/pkg/errors v0.9.1
 	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20221213084338-a8ffdd2b87e3
 	github.com/rancher/rancher/pkg/apis v0.0.0-20230109234348-70ea547c0ffe
 	k8s.io/apiextensions-apiserver v0.25.4
@@ -50,6 +51,7 @@ require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-logr/zapr v1.2.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect
 	github.com/go-openapi/swag v0.19.14 // indirect
@@ -70,7 +72,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,7 @@ github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-logr/zapr v0.1.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-logr/zapr v0.4.0/go.mod h1:tabnROwaDl0UNxkVeFRbY8bwB37GwRv0P8lg6aAiEnk=
 github.com/go-logr/zapr v1.2.0 h1:n4JnPI1T3Qq1SFEi/F8rwLrZERp2bso19PJZDB9dayk=
+github.com/go-logr/zapr v1.2.0/go.mod h1:Qa4Bsj2Vb+FAVeAKsLD8RLQ+YRJB8YDmOAKxaBQf7Ro=
 github.com/go-openapi/analysis v0.0.0-20180825180245-b006789cd277/go.mod h1:k70tL6pCuVxPJOHXQ+wIac1FUrvNkHolPie/cLEU6hI=
 github.com/go-openapi/analysis v0.17.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
 github.com/go-openapi/analysis v0.18.0/go.mod h1:IowGgpVeD0vNm45So8nr+IcQ3pxVtpRoBWb8PVZO0ik=
@@ -320,6 +321,7 @@ github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -1391,6 +1393,7 @@ k8s.io/component-base v0.0.0-20191214190519-d868452632e2/go.mod h1:wupxkh1T/oUDq
 k8s.io/component-base v0.17.2/go.mod h1:zMPW3g5aH7cHJpKYQ/ZsGMcgbsA/VyhEugF3QT1awLs=
 k8s.io/component-base v0.18.0/go.mod h1:u3BCg0z1uskkzrnAKFzulmYaEpZF7XC9Pf/uFyb1v2c=
 k8s.io/component-base v0.22.2/go.mod h1:5Br2QhI9OTe79p+TzPe9JKNQYvEKbq9rTJDWllunGug=
+k8s.io/component-base v0.25.4 h1:n1bjg9Yt+G1C0WnIDJmg2fo6wbEU1UGMRiQSjmj7hNQ=
 k8s.io/component-helpers v0.22.2/go.mod h1:+N61JAR9aKYSWbnLA88YcFr9K/6ISYvRNybX7QW7Rs8=
 k8s.io/gengo v0.0.0-20190128074634-0689ccc1d7d6/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20190822140433-26a664648505/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/pkg/test/cleanup.go
+++ b/pkg/test/cleanup.go
@@ -1,0 +1,94 @@
+package test
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	cacheSyncBackoff = wait.Backoff{
+		Duration: 100 * time.Millisecond,
+		Factor:   1.5,
+		Steps:    8,
+		Jitter:   0.4,
+	}
+)
+
+// CleanupAndWait deletes all the given objects and waits for the cache to be updated accordingly.
+func CleanupAndWait(ctx context.Context, cl client.Client, objs ...client.Object) error {
+	if err := cleanup(ctx, cl, objs...); err != nil {
+		return err
+	}
+
+	// Makes sure the cache is updated with the deleted object
+	errs := []error{}
+	for _, o := range objs {
+		// Ignoring namespaces because in testenv the namespace cleaner is not running.
+		if o.GetObjectKind().GroupVersionKind().GroupKind() == corev1.SchemeGroupVersion.WithKind("Namespace").GroupKind() {
+			continue
+		}
+
+		oCopy := o.DeepCopyObject().(client.Object)
+		key := client.ObjectKeyFromObject(o)
+		err := wait.ExponentialBackoff(
+			cacheSyncBackoff,
+			func() (done bool, err error) {
+				if err := cl.Get(ctx, key, oCopy); err != nil {
+					if apierrors.IsNotFound(err) {
+						return true, nil
+					}
+					if o.GetName() == "" { // resource is being deleted
+						return true, nil
+					}
+					return false, err
+				}
+				return false, nil
+			})
+		errs = append(errs, errors.Wrapf(err, "key %s, %s is not being deleted from the testenv client cache", o.GetObjectKind().GroupVersionKind().String(), key))
+	}
+	return kerrors.NewAggregate(errs)
+}
+
+// cleanup deletes all the given objects.
+func cleanup(ctx context.Context, cl client.Client, objs ...client.Object) error {
+	errs := []error{}
+	for _, o := range objs {
+		copyObj := o.DeepCopyObject().(client.Object)
+
+		if err := cl.Get(ctx, client.ObjectKeyFromObject(o), copyObj); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			if o.GetName() == "" { // resource is being deleted
+				continue
+			}
+			errs = append(errs, err)
+			continue
+		}
+
+		// Remove finalizers from the object
+		if copyObj.GetFinalizers() != nil {
+			copyObj.SetFinalizers(nil)
+		}
+
+		err := cl.Update(ctx, copyObj)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		errs = append(errs, err)
+
+		err = cl.Delete(ctx, copyObj)
+		if apierrors.IsNotFound(err) {
+			continue
+		}
+		errs = append(errs, err)
+	}
+	return kerrors.NewAggregate(errs)
+}

--- a/pkg/test/envtest.go
+++ b/pkg/test/envtest.go
@@ -1,0 +1,59 @@
+package test
+
+import (
+	"errors"
+	"path"
+	goruntime "runtime"
+
+	aksv1 "github.com/rancher/aks-operator/pkg/apis/aks.cattle.io/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+var (
+	scheme = runtime.NewScheme()
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(aksv1.AddToScheme(scheme))
+}
+
+func StartEnvTest(testEnv *envtest.Environment) (*rest.Config, client.Client, error) {
+	// Get the root of the current file to use in CRD paths.
+	_, filename, _, _ := goruntime.Caller(0) //nolint:dogsled
+	root := path.Join(path.Dir(filename), "..", "..", "..", "aks-operator")
+
+	testEnv.CRDs = []*apiextensionsv1.CustomResourceDefinition{
+		// Add later if needed.
+	}
+	testEnv.CRDDirectoryPaths = []string{
+		path.Join(root, "charts", "aks-operator-crd", "templates"),
+	}
+	testEnv.ErrorIfCRDPathMissing = true
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if cfg == nil {
+		return nil, nil, errors.New("envtest.Environment.Start() returned nil config")
+	}
+
+	cl, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return cfg, cl, nil
+}
+
+func StopEnvTest(testEnv *envtest.Environment) error {
+	return testEnv.Stop()
+}


### PR DESCRIPTION
This PR introduces the usage of [envtest](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest) for writing unit tests. Envtest will help us test the controller with a real client.