### PR TITLE
Enable AKS to use Outbound type of userDefinedRouting

### DIFF
--- a/charts/aks-operator-crd/templates/crds.yaml
+++ b/charts/aks-operator-crd/templates/crds.yaml
@@ -143,6 +143,9 @@ spec:
                   type: object
                 nullable: true
                 type: array
+              outboundType:
+                nullable: true
+                type: string
               podCidr:
                 nullable: true
                 type: string

--- a/controller/aks-cluster-config-handler.go
+++ b/controller/aks-cluster-config-handler.go
@@ -636,6 +636,7 @@ func (h *Handler) buildUpstreamClusterState(ctx context.Context, spec *aksv1.AKS
 		upstreamSpec.NetworkServiceCIDR = networkProfile.ServiceCidr
 		upstreamSpec.NetworkPolicy = to.StringPtr(string(networkProfile.NetworkPolicy))
 		upstreamSpec.NetworkPodCIDR = networkProfile.PodCidr
+		upstreamSpec.OutboundType = to.StringPtr(string(networkProfile.OutboundType))
 		upstreamSpec.LoadBalancerSKU = to.StringPtr(string(networkProfile.LoadBalancerSku))
 	}
 

--- a/examples/create-example-udr.yaml
+++ b/examples/create-example-udr.yaml
@@ -11,7 +11,7 @@ spec:
   azureCredentialSecret: "REPLACE_WITH_K8S_SECRETS_NAME"
   privateCluster: false,
   linuxAdminUsername: "rancher-user",
-  loadBalancerSku: "standard"
+  loadBalancerSku: ""
   sshPublicKey: "REPLACE_WITH_SSH_PUBLIC_KEY",
   kubernetesVersion: "1.19.9"
   nodePools:
@@ -36,4 +36,4 @@ spec:
     minCount: 1
     maxCount: 6
     availabilityZones: [ "1", "2", "3" ]
-  outboundType: "loadBalancer"
+  outboundType: "userDefinedRouting"

--- a/pkg/aks/create.go
+++ b/pkg/aks/create.go
@@ -64,6 +64,15 @@ func createManagedCluster(ctx context.Context, cred *Credentials, workplacesClie
 
 	networkProfile := &containerservice.NetworkProfile{}
 
+	switch to.String(spec.OutboundType) {
+	case string(containerservice.LoadBalancer):
+		networkProfile.OutboundType = containerservice.LoadBalancer
+	case string(containerservice.UserDefinedRouting):
+		networkProfile.OutboundType = containerservice.UserDefinedRouting
+	case "":
+		networkProfile.OutboundType = containerservice.LoadBalancer
+	}
+
 	switch to.String(spec.NetworkPolicy) {
 	case string(containerservice.NetworkPolicyAzure):
 		networkProfile.NetworkPolicy = containerservice.NetworkPolicyAzure
@@ -97,7 +106,7 @@ func createManagedCluster(ctx context.Context, cred *Credentials, workplacesClie
 		logrus.Warnf("loadBalancerSKU 'basic' is not supported")
 		networkProfile.LoadBalancerSku = containerservice.Basic
 	case "":
-		networkProfile.LoadBalancerSku = containerservice.Standard
+		networkProfile.LoadBalancerSku = ""
 	}
 
 	virtualNetworkResourceGroup := spec.ResourceGroup

--- a/pkg/apis/aks.cattle.io/v1/types.go
+++ b/pkg/apis/aks.cattle.io/v1/types.go
@@ -48,6 +48,7 @@ type AKSClusterConfigSpec struct {
 	NetworkServiceCIDR          *string           `json:"serviceCidr" norman:"pointer"`
 	NetworkDockerBridgeCIDR     *string           `json:"dockerBridgeCidr" norman:"pointer"`
 	NetworkPodCIDR              *string           `json:"podCidr" norman:"pointer"`
+	OutboundType                *string           `json:"outboundType" norman:"pointer"`
 	LoadBalancerSKU             *string           `json:"loadBalancerSku" norman:"pointer"`
 	NetworkPolicy               *string           `json:"networkPolicy" norman:"pointer"`
 	LinuxAdminUsername          *string           `json:"linuxAdminUsername,omitempty" norman:"pointer"`

--- a/pkg/apis/aks.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/aks.cattle.io/v1/zz_generated_deepcopy.go
@@ -139,6 +139,11 @@ func (in *AKSClusterConfigSpec) DeepCopyInto(out *AKSClusterConfigSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.OutboundType != nil {
+		in, out := &in.OutboundType, &out.OutboundType
+		*out = new(string)
+		**out = **in
+	}
 	if in.LoadBalancerSKU != nil {
 		in, out := &in.LoadBalancerSKU, &out.LoadBalancerSKU
 		*out = new(string)


### PR DESCRIPTION
With UDR setup, there is no need to provision loadbalancer for `egress` communication. Egress will be routed to existing route table in the VNET/Subnet. 
This will be useful in the setup where creation of public loadbalancer is prohibited.
