### PR TITLE
🐛  Fix aks credentials passing to buildUpstreamClusterState() func

### DIFF
--- a/controller/aks-cluster-config-handler.go
+++ b/controller/aks-cluster-config-handler.go
@@ -552,7 +552,7 @@ func (h *Handler) getClusterKubeConfig(ctx context.Context, spec *aksv1.AKSClust
 	return config, nil
 }
 
-func (h *Handler) buildUpstreamClusterState(ctx context.Context, spec *aksv1.AKSClusterConfigSpec) (*aksv1.AKSClusterConfigSpec, error) {
+func (h *Handler) buildUpstreamClusterState(ctx context.Context, credentials *aks.Credentials, spec *aksv1.AKSClusterConfigSpec) (*aksv1.AKSClusterConfigSpec, error) {
 	upstreamSpec := &aksv1.AKSClusterConfigSpec{}
 
 	clusterState, err := h.azureClients.clustersClient.Get(ctx, spec.ResourceGroup, spec.ClusterName)

--- a/controller/external.go
+++ b/controller/external.go
@@ -61,5 +61,5 @@ func BuildUpstreamClusterState(ctx context.Context, secretsCache wranglerv1.Secr
 			clustersClient: clustersClient,
 		},
 	}
-	return h.buildUpstreamClusterState(ctx, spec)
+	return h.buildUpstreamClusterState(ctx, credentials, spec)
 }


### PR DESCRIPTION
Possibly fixes: https://github.com/rancher/aks-operator/issues/98

Signed-off by: Furkat Gofurov (furkat.gofurov@suse.com)