### PR TITLE
Update k8s version in e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OPERATOR_CHART?=$(shell find $(ROOT_DIR) -type f -name "rancher-aks-operator-[0-
 CRD_CHART?=$(shell find $(ROOT_DIR) -type f -name "rancher-aks-operator-crd*.tgz" -print)
 CHART_VERSION?=$(subst v,,$(GIT_TAG))
 REPO?=ghcr.io/rancher/aks-operator
-KUBE_VERSION?="v1.24.6"
+KUBE_VERSION?="v1.25.8"
 CLUSTER_NAME?="operator-e2e"
 E2E_CONF_FILE ?= $(ROOT_DIR)/test/e2e/config/config.yaml
 

--- a/scripts/setup-kind-cluster.sh
+++ b/scripts/setup-kind-cluster.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-KUBE_VERSION=${KUBE_VERSION:-v1.24.6}
+KUBE_VERSION=${KUBE_VERSION:-v1.25.8}
 CLUSTER_NAME="${CLUSTER_NAME:-operator-e2e}"
 
 if ! kind get clusters | grep "$CLUSTER_NAME"; then

--- a/test/e2e/config/config.yaml
+++ b/test/e2e/config/config.yaml
@@ -8,5 +8,5 @@ artifactsDir: ../../_artifacts
 certManagerVersion: v1.9.2
 certManagerChartURL: https://charts.jetstack.io/charts/cert-manager-${CERT_MANAGER_VERSION}.tgz
 
-rancherVersion: 2.7.0
+rancherVersion: 2.7.2
 rancherChartURL: https://releases.rancher.com/server-charts/latest/rancher-${RANCHER_VERSION}.tgz

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -146,6 +146,8 @@ var _ = BeforeSuite(func() {
 					"bootstrapPassword=admin",
 					"--set",
 					"replicas=1",
+					"--set",
+					"global.cattle.psp.enabled=false",
 					"--set", fmt.Sprintf("hostname=%s.%s", e2eCfg.ExternalIP, e2eCfg.MagicDNS),
 					"--create-namespace",
 					rancherName,

--- a/test/e2e/templates/basic-cluster.yaml
+++ b/test/e2e/templates/basic-cluster.yaml
@@ -7,7 +7,7 @@ spec:
   clusterName: cluster
   dnsPrefix: basic-cluster-dns
   imported: false
-  kubernetesVersion: 1.24.6
+  kubernetesVersion: 1.25.5
   linuxAdminUsername: azureuser
   loadBalancerSku: Standard
   networkPlugin: kubenet
@@ -21,7 +21,7 @@ spec:
     maxPods: 110
     mode: System
     name: agentpool
-    orchestratorVersion: 1.24.6
+    orchestratorVersion: 1.25.5
     osDiskSizeGB: 30
     osDiskType: Managed
     osType: Linux


### PR DESCRIPTION
Update k8s version because 1.24.6 was deprecated by Microsoft.