### PR TITLE
Skip updating dnsPrefix for private DNS zones

### DIFF
--- a/controller/aks-cluster-config-handler.go
+++ b/controller/aks-cluster-config-handler.go
@@ -567,10 +567,9 @@ func (h *Handler) buildUpstreamClusterState(ctx context.Context, credentials *ak
 	upstreamSpec.KubernetesVersion = clusterState.KubernetesVersion
 
 	// set DNS prefix
-	if clusterState.DNSPrefix == nil {
-		return nil, fmt.Errorf("cannot detect cluster [%s] upstream DNS prefix", spec.ClusterName)
+	if clusterState.DNSPrefix != nil {
+		upstreamSpec.DNSPrefix = clusterState.DNSPrefix
 	}
-	upstreamSpec.DNSPrefix = clusterState.DNSPrefix
 
 	// set tags
 	upstreamSpec.Tags = make(map[string]string)

--- a/controller/aks-cluster-config-handler_test.go
+++ b/controller/aks-cluster-config-handler_test.go
@@ -908,6 +908,6 @@ var _ = Describe("buildUpstreamClusterState", func() {
 		clusterClientMock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(*clusterState, nil)
 
 		_, err := handler.buildUpstreamClusterState(ctx, credentials, &aksConfig.Spec)
-		Expect(err).To(HaveOccurred())
+		Expect(err).ToNot(HaveOccurred())
 	})
 })


### PR DESCRIPTION
For imported private clusters with private DNS zones we can skip setting dnsPrefix, because it will be nil value. DNSPrefix can be updated for existing clusters.

Issue: https://github.com/rancher/aks-operator/issues/169