### PR TITLE
Prevent rancher from downgrading chart version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ GIT_TAG?=$(shell git describe --abbrev=0 --tags 2>/dev/null || echo "v0.0.0" )
 TAG?=${GIT_TAG}-${GIT_COMMIT_SHORT}
 OPERATOR_CHART?=$(shell find $(ROOT_DIR) -type f -name "rancher-aks-operator-[0-9]*.tgz" -print)
 CRD_CHART?=$(shell find $(ROOT_DIR) -type f -name "rancher-aks-operator-crd*.tgz" -print)
-CHART_VERSION?=$(subst v,,$(GIT_TAG))
+CHART_VERSION?=900 # Only used in e2e to avoid downgrades from rancher
 REPO?=ghcr.io/rancher/aks-operator
 KUBE_VERSION?="v1.25.8"
-CLUSTER_NAME?="operator-e2e"
+CLUSTER_NAME?="aks-operator-e2e"
 E2E_CONF_FILE ?= $(ROOT_DIR)/test/e2e/config/config.yaml
 
 ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
@@ -22,7 +22,7 @@ MOCKGEN_VER := v1.6.0
 MOCKGEN_BIN := mockgen
 MOCKGEN := $(BIN_DIR)/$(MOCKGEN_BIN)-$(MOCKGEN_VER)
 
-GINKGO_VER := v2.8.4
+GINKGO_VER := v2.9.2
 GINKGO_BIN := ginkgo
 GINKGO := $(BIN_DIR)/$(GINKGO_BIN)-$(GINKGO_VER)
 
@@ -118,7 +118,7 @@ charts:
 
 .PHONY: setup-kind
 setup-kind:
-	KUBE_VERSION=${KUBE_VERSION} $(ROOT_DIR)/scripts/setup-kind-cluster.sh
+	KUBE_VERSION=${KUBE_VERSION} CLUSTER_NAME=$(CLUSTER_NAME) $(ROOT_DIR)/scripts/setup-kind-cluster.sh
 
 .PHONY: e2e-tests
 e2e-tests: $(GINKGO) charts

--- a/scripts/setup-kind-cluster.sh
+++ b/scripts/setup-kind-cluster.sh
@@ -25,7 +25,7 @@ set -e
 
 kubectl cluster-info --context kind-$CLUSTER_NAME
 echo "Sleep to give times to node to populate with all info"
-kubectl wait --for=condition=Ready node/operator-e2e-control-plane
+kubectl wait --for=condition=Ready node/$CLUSTER_NAME-control-plane
 # Label the nodes with node-role.kubernetes.io/master as it appears that
 # label is no longer added on >=1.24.X clusters while it was set on <=1.23.X
 # https://github.com/kubernetes/enhancements/tree/master/keps/sig-cluster-lifecycle/kubeadm/2067-rename-master-label-taint


### PR DESCRIPTION
If the chart version is set to some unrealistically high version like 900, rancher will not reconcile it. Currently, when aks controller starts returning errors rancher will try to fix the chart:

```
mac:aks-operator ademicev$ kubectl get deployment aks-config-operator -n cattle-system -o yaml | grep image:
        image: ghcr.io/rancher/aks-operator:v0.0.0-fbfbe49
mac:aks-operator ademicev$ kubectl get deployment aks-config-operator -n cattle-system -o yaml | grep image:
        image: rancher/aks-operator:v1.1.0
```
changes in the PR will prevent this from happening