### PR TITLE
Add dnsPrefix to create example cluster

### DIFF
--- a/examples/create-example.yaml
+++ b/examples/create-example.yaml
@@ -9,6 +9,7 @@ spec:
   baseUrl: "https://management.azure.com/"
   authBaseUrl: "https://login.microsoftonline.com"
   azureCredentialSecret: "REPLACE_WITH_K8S_SECRETS_NAME"
+  dnsPrefix: "example-dns"
   privateCluster: false,
   linuxAdminUsername: "rancher-user",
   sshPublicKey: "REPLACE_WITH_SSH_PUBLIC_KEY",


### PR DESCRIPTION
Add `dnsPrefix` option to create example AKS cluster, otherwise it will fail.