### PR TITLE
🌱 Enable more linters in aks operator

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,19 +1,33 @@
 run:
   timeout: 5m
+  go: "1.19"
   skip-files:
     - "zz_generated_*"
   skip-dirs:
     - pkg/generated
   tests: false
+  allow-parallel-runners: true
+
 output:
   format: github-actions
+
 linters:
+  disable-all: true
   enable:
-    - revive # replacement for golint
     - dupl # check duplicated code
     - goconst # check strings that can turn into constants
     - gofmt # check fmt
     - goimports # check imports
+    - gosec # check for security problems
+    - govet # check vet
+    - importas # check consistent import aliasing
+    - ineffassign # check ineffectual assignments
+    - misspell # check for misspelled English words
+    - nakedret # check naked returns in functions
+    - prealloc # check preallocated slice declarations
+    - revive # replacement for golint
+    - unconvert # check redundant type conversions
+    - whitespace # check for trailing whitespace and tabs
 linters-settings:
   revive:
     rules:
@@ -40,6 +54,36 @@ linters-settings:
       - name: unused-parameter
       - name: unreachable-code
       - name: redefines-builtin-id
+  importas:
+    no-unaliased: true
+    alias:
+      # Kubernetes
+      - pkg: k8s.io/api/core/v1
+        alias: corev1
+      - pkg: k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1
+        alias: apiextensionsv1
+      - pkg: k8s.io/api/apps/v1
+        alias: appsv1
+      - pkg: k8s.io/apimachinery/pkg/apis/meta/v1
+        alias: metav1
+      - pkg: k8s.io/apimachinery/pkg/util/runtime
+        alias: utilruntime
+      - pkg: sigs.k8s.io/controller-runtime/pkg/client
+        alias: runtimeclient
+      - pkg: k8s.io/apimachinery/pkg/api/errors
+        alias: apierrors
+      - pkg: k8s.io/apimachinery/pkg/util/errors
+        alias: kerrors
+      - pkg: k8s.io/client-go/kubernetes/scheme
+        alias: clientgoscheme
+      # Rancher AKS operator
+      - pkg: github.com/rancher/aks-operator/pkg/apis/aks.cattle.io/v1
+        alias: aksv1
+      - pkg: github.com/rancher/aks-operator/pkg/generated/controllers/aks.cattle.io/v1
+        alias: akscontrollers
+      # Core Rancher
+      - pkg: github.com/rancher/rancher/pkg/apis/management.cattle.io/v3
+        alias: managementv3
 issues:
   exclude-rules:
   - linters:

--- a/pkg/aks/check.go
+++ b/pkg/aks/check.go
@@ -115,7 +115,6 @@ var regionToOmsRegionMap = map[string]string{
 
 func CheckLogAnalyticsWorkspaceForMonitoring(ctx context.Context, client services.WorkplacesClientInterface,
 	location string, group string, wsg string, wsn string) (workspaceID string, err error) {
-
 	workspaceRegion, ok := regionToOmsRegionMap[location]
 	if !ok {
 		return "", fmt.Errorf("region %s not supported for Log Analytics workspace", location)
@@ -158,7 +157,7 @@ func CheckLogAnalyticsWorkspaceForMonitoring(ctx context.Context, client service
 	if asyncErr != nil {
 		return "", asyncErr
 	}
-
+	workspaceID = ""
 	err = wait.Poll(5*time.Second, 30*time.Second, func() (bool, error) {
 		ret, err := client.AsyncCreateUpdateResult(asyncRet)
 		if err != nil {
@@ -168,7 +167,10 @@ func CheckLogAnalyticsWorkspaceForMonitoring(ctx context.Context, client service
 		workspaceID = *ret.ID
 		return true, nil
 	})
-	return
+	if err != nil {
+		return "", err
+	}
+	return workspaceID, nil
 }
 
 func generateUniqueLogWorkspace(workspaceName string) string {

--- a/pkg/aks/client.go
+++ b/pkg/aks/client.go
@@ -15,8 +15,8 @@ import (
 	"github.com/rancher/machine/drivers/azure/azureutil"
 	wranglerv1 "github.com/rancher/wrangler/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -109,10 +109,10 @@ func GetSecrets(_ wranglerv1.SecretCache, secretClient wranglerv1.SecretClient, 
 }
 
 type secretClient interface {
-	Update(*v1.Secret) (*v1.Secret, error)
+	Update(*corev1.Secret) (*corev1.Secret, error)
 }
 
-func GetCachedTenantID(secretClient secretClient, subscriptionID string, secret *v1.Secret) (string, error) {
+func GetCachedTenantID(secretClient secretClient, subscriptionID string, secret *corev1.Secret) (string, error) {
 	annotations := secret.GetAnnotations()
 	if annotations == nil {
 		annotations = map[string]string{}
@@ -145,7 +145,7 @@ func GetCachedTenantID(secretClient secretClient, subscriptionID string, secret 
 	annotations[tenantIDTimestampAnnotation] = time.Now().UTC().Format(time.RFC3339)
 	secret.Annotations = annotations
 	_, err = secretClient.Update(secret)
-	if errors.IsConflict(err) {
+	if apierrors.IsConflict(err) {
 		// Ignore errors when updating the secret object. If the secret cannot be updated
 		// (perhaps due to a conflict error), the tenant ID will be re-fetched on the next reconcile loop.
 		logrus.Debugf("encountered error while updating secret, ignoring: %v", err)

--- a/pkg/aks/create.go
+++ b/pkg/aks/create.go
@@ -29,7 +29,6 @@ func CreateResourceGroup(ctx context.Context, groupsClient services.ResourceGrou
 // We are provisioning a brand new one.
 func CreateCluster(ctx context.Context, cred *Credentials, clusterClient services.ManagedClustersClientInterface, workplaceClient services.WorkplacesClientInterface,
 	spec *aksv1.AKSClusterConfigSpec, phase string) error {
-
 	managedCluster, err := createManagedCluster(ctx, cred, workplaceClient, spec, phase)
 	if err != nil {
 		return err

--- a/pkg/aks/update.go
+++ b/pkg/aks/update.go
@@ -18,7 +18,6 @@ func UpdateClusterTags(ctx context.Context, clusterClient services.ManagedCluste
 // and then only updates managed fields.
 func UpdateCluster(ctx context.Context, cred *Credentials, clusterClient services.ManagedClustersClientInterface, workplaceClient services.WorkplacesClientInterface,
 	spec *aksv1.AKSClusterConfigSpec, phase string) error {
-
 	// Create a new managed cluster from the AKS cluster config
 	desiredCluster, err := createManagedCluster(ctx, cred, workplaceClient, spec, phase)
 	if err != nil {

--- a/pkg/codegen/main.go
+++ b/pkg/codegen/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/rancher/wrangler/pkg/controller-gen/args"
 	"github.com/rancher/wrangler/pkg/crd"
 	"github.com/rancher/wrangler/pkg/yaml"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -33,9 +33,9 @@ func main() {
 			// In this controller we will use wrangler-api for apps api group
 			"": {
 				Types: []interface{}{
-					v1.Pod{},
-					v1.Node{},
-					v1.Secret{},
+					corev1.Pod{},
+					corev1.Node{},
+					corev1.Secret{},
 				},
 				InformersPackage: "k8s.io/client-go/informers",
 				ClientSetPackage: "k8s.io/client-go/kubernetes",

--- a/pkg/test/cleanup.go
+++ b/pkg/test/cleanup.go
@@ -9,7 +9,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -22,7 +22,7 @@ var (
 )
 
 // CleanupAndWait deletes all the given objects and waits for the cache to be updated accordingly.
-func CleanupAndWait(ctx context.Context, cl client.Client, objs ...client.Object) error {
+func CleanupAndWait(ctx context.Context, cl runtimeclient.Client, objs ...runtimeclient.Object) error {
 	if err := cleanup(ctx, cl, objs...); err != nil {
 		return err
 	}
@@ -35,8 +35,8 @@ func CleanupAndWait(ctx context.Context, cl client.Client, objs ...client.Object
 			continue
 		}
 
-		oCopy := o.DeepCopyObject().(client.Object)
-		key := client.ObjectKeyFromObject(o)
+		oCopy := o.DeepCopyObject().(runtimeclient.Object)
+		key := runtimeclient.ObjectKeyFromObject(o)
 		err := wait.ExponentialBackoff(
 			cacheSyncBackoff,
 			func() (done bool, err error) {
@@ -57,12 +57,12 @@ func CleanupAndWait(ctx context.Context, cl client.Client, objs ...client.Object
 }
 
 // cleanup deletes all the given objects.
-func cleanup(ctx context.Context, cl client.Client, objs ...client.Object) error {
+func cleanup(ctx context.Context, cl runtimeclient.Client, objs ...runtimeclient.Object) error {
 	errs := []error{}
 	for _, o := range objs {
-		copyObj := o.DeepCopyObject().(client.Object)
+		copyObj := o.DeepCopyObject().(runtimeclient.Object)
 
-		if err := cl.Get(ctx, client.ObjectKeyFromObject(o), copyObj); err != nil {
+		if err := cl.Get(ctx, runtimeclient.ObjectKeyFromObject(o), copyObj); err != nil {
 			if apierrors.IsNotFound(err) {
 				continue
 			}

--- a/pkg/test/envtest.go
+++ b/pkg/test/envtest.go
@@ -11,7 +11,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
@@ -24,7 +24,7 @@ func init() {
 	utilruntime.Must(aksv1.AddToScheme(scheme))
 }
 
-func StartEnvTest(testEnv *envtest.Environment) (*rest.Config, client.Client, error) {
+func StartEnvTest(testEnv *envtest.Environment) (*rest.Config, runtimeclient.Client, error) {
 	// Get the root of the current file to use in CRD paths.
 	_, filename, _, _ := goruntime.Caller(0) //nolint:dogsled
 	root := path.Join(path.Dir(filename), "..", "..", "..", "aks-operator")
@@ -46,7 +46,7 @@ func StartEnvTest(testEnv *envtest.Environment) (*rest.Config, client.Client, er
 		return nil, nil, errors.New("envtest.Environment.Start() returned nil config")
 	}
 
-	cl, err := client.New(cfg, client.Options{Scheme: scheme})
+	cl, err := runtimeclient.New(cfg, runtimeclient.Options{Scheme: scheme})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/test/e2e/config/config.go
+++ b/test/e2e/config/config.go
@@ -144,7 +144,7 @@ func substituteVersions(config *E2EConfig) error {
 		return config.CertManagerVersion
 	})
 	if err != nil {
-		return fmt.Errorf("failed to substiture cert manager chart url: %w", err)
+		return fmt.Errorf("failed to substitute cert manager chart url: %w", err)
 	}
 	config.CertManagerChartURL = certManagerURL
 
@@ -152,7 +152,7 @@ func substituteVersions(config *E2EConfig) error {
 		return config.RancherVersion
 	})
 	if err != nil {
-		return fmt.Errorf("failed to substiture rancher chart url: %w", err)
+		return fmt.Errorf("failed to substitute rancher chart url: %w", err)
 	}
 	config.RancherChartURL = rancherURL
 


### PR DESCRIPTION
This PR:

- Enables more linters in the .golangci.yaml to have a better aligned package import aliases
- Fixes all lint errors as a consequence of newly added linters