### PR TITLE
Add field to set custom name for AKS node resource group

### DIFF
--- a/charts/aks-operator-crd/templates/crds.yaml
+++ b/charts/aks-operator-crd/templates/crds.yaml
@@ -143,6 +143,9 @@ spec:
                   type: object
                 nullable: true
                 type: array
+              nodeResourceGroup:
+                nullable: true
+                type: string
               outboundType:
                 nullable: true
                 type: string

--- a/controller/aks-cluster-config-handler.go
+++ b/controller/aks-cluster-config-handler.go
@@ -214,6 +214,10 @@ func (h *Handler) recordError(onChange func(key string, config *aksv1.AKSCluster
 }
 
 func (h *Handler) createCluster(config *aksv1.AKSClusterConfig) (*aksv1.AKSClusterConfig, error) {
+	// TODO: delete this test
+	// ClusterName must be 1-63 characters long
+	// NodeResourceGroupName must be no greater than 80 characters in length
+	config.Spec.NodeResourceGroup = to.StringPtr("MC_csalas_from_rancher")
 	if err := h.validateConfig(config); err != nil {
 		return config, err
 	}
@@ -257,6 +261,7 @@ func (h *Handler) createCluster(config *aksv1.AKSClusterConfig) (*aksv1.AKSClust
 	}
 
 	logrus.Infof("Creating AKS cluster [%s]", config.Spec.ClusterName)
+	logrus.Infof("Creating AKS cluster [%s] with node resource group [%s]", config.Spec.ClusterName, *config.Spec.NodeResourceGroup)
 
 	err = aks.CreateCluster(ctx, &h.azureClients.credentials, h.azureClients.clustersClient, h.azureClients.workplacesClient, &config.Spec, config.Status.Phase)
 	if err != nil {

--- a/controller/aks-cluster-config-handler.go
+++ b/controller/aks-cluster-config-handler.go
@@ -214,10 +214,6 @@ func (h *Handler) recordError(onChange func(key string, config *aksv1.AKSCluster
 }
 
 func (h *Handler) createCluster(config *aksv1.AKSClusterConfig) (*aksv1.AKSClusterConfig, error) {
-	// TODO: delete this test
-	// ClusterName must be 1-63 characters long
-	// NodeResourceGroupName must be no greater than 80 characters in length
-	config.Spec.NodeResourceGroup = to.StringPtr("MC_csalas_from_rancher")
 	if err := h.validateConfig(config); err != nil {
 		return config, err
 	}
@@ -261,7 +257,6 @@ func (h *Handler) createCluster(config *aksv1.AKSClusterConfig) (*aksv1.AKSClust
 	}
 
 	logrus.Infof("Creating AKS cluster [%s]", config.Spec.ClusterName)
-	logrus.Infof("Creating AKS cluster [%s] with node resource group [%s]", config.Spec.ClusterName, *config.Spec.NodeResourceGroup)
 
 	err = aks.CreateCluster(ctx, &h.azureClients.credentials, h.azureClients.clustersClient, h.azureClients.workplacesClient, &config.Spec, config.Status.Phase)
 	if err != nil {

--- a/pkg/aks/create.go
+++ b/pkg/aks/create.go
@@ -33,6 +33,7 @@ func CreateCluster(ctx context.Context, cred *Credentials, clusterClient service
 	if err != nil {
 		return err
 	}
+	logrus.Infof("managedCluster in CreateCluster() is %s", *managedCluster.NodeResourceGroup)
 
 	_, err = clusterClient.CreateOrUpdate(
 		ctx,
@@ -60,6 +61,12 @@ func createManagedCluster(ctx context.Context, cred *Credentials, workplacesClie
 			managedCluster.Tags[key] = to.StringPtr(val)
 		}
 	}
+
+	// TODO: new field NodeResourceGroupName
+	if len(to.String(spec.NodeResourceGroup)) > 80 {
+		return nil, fmt.Errorf("nodeResourceGroupName '%s' is too long, must be less than 80 characters", to.String(spec.NodeResourceGroup))
+	}
+	managedCluster.ManagedClusterProperties.NodeResourceGroup = spec.NodeResourceGroup
 
 	networkProfile := &containerservice.NetworkProfile{}
 

--- a/pkg/apis/aks.cattle.io/v1/types.go
+++ b/pkg/apis/aks.cattle.io/v1/types.go
@@ -48,6 +48,7 @@ type AKSClusterConfigSpec struct {
 	NetworkServiceCIDR          *string           `json:"serviceCidr" norman:"pointer"`
 	NetworkDockerBridgeCIDR     *string           `json:"dockerBridgeCidr" norman:"pointer"`
 	NetworkPodCIDR              *string           `json:"podCidr" norman:"pointer"`
+	NodeResourceGroup           *string           `json:"nodeResourceGroup,omitempty" norman:"pointer"`
 	OutboundType                *string           `json:"outboundType" norman:"pointer"`
 	LoadBalancerSKU             *string           `json:"loadBalancerSku" norman:"pointer"`
 	NetworkPolicy               *string           `json:"networkPolicy" norman:"pointer"`

--- a/pkg/apis/aks.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/aks.cattle.io/v1/zz_generated_deepcopy.go
@@ -139,6 +139,11 @@ func (in *AKSClusterConfigSpec) DeepCopyInto(out *AKSClusterConfigSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.NodeResourceGroup != nil {
+		in, out := &in.NodeResourceGroup, &out.NodeResourceGroup
+		*out = new(string)
+		**out = **in
+	}
 	if in.OutboundType != nil {
 		in, out := &in.OutboundType, &out.OutboundType
 		*out = new(string)


### PR DESCRIPTION
Issue #207 

## Problem

When creating new clusters, AKS deployments span two resource groups.
- The first resource group is created by the user and can be configured from Rancher UI when creating a new AKS cluster. This resource group contains the Kubernetes Service resource.
- The second resource group, or node resource group, is automatically created by Azure and contains all of the infrastructure resources associated with the cluster. If it is not specified, Azure will create this resource group with a name that follows the format `MC_<resource-group1>_<cluster-name>_<location>`. **The maximum length of this name is 80 characters and cluster creation will fail if the generated string exceeds this limitation**.

## Solution

Two different cases are identified.
- **Custom node resource group name**: a new field is added to `AKSClusterConfigSpec` [NodeResourceGroup](https://github.com/salasberryfin/aks-operator/blob/f927c66b534622110dcbc149e5a34718d7115b28/pkg/apis/aks.cattle.io/v1/types.go#L51). This new field could be set from the UI when creating a new cluster (pending implementation): rancher/dashboard#8980. The length of this field must be validated, as is done for the `ClusterName`.
- **Default node resource group name**: if the new field [NodeResourceGroup](https://github.com/salasberryfin/aks-operator/blob/f927c66b534622110dcbc149e5a34718d7115b28/pkg/apis/aks.cattle.io/v1/types.go#L51) is empty, the default resource group name is used. The name is truncated to 80 characters if it exceeds the maximum length.