### PR TITLE
feat: publish nightly charts

### DIFF
--- a/.github/workflows/nightly-publish.yaml
+++ b/.github/workflows/nightly-publish.yaml
@@ -3,11 +3,14 @@ on:
   schedule:
     - cron: '0 1 * * *'
 jobs:
-  nightly:
+  nightly_image:
     env:
-        REPO: ttl.sh/aks-operator-nightly
+        REPO_BASE: ttl.sh/aks-operator-nightly
         TAG: 1d
     runs-on: ubuntu-latest
+    outputs:
+      REPO: ${{ steps.setoutputs.outputs.repo}}
+      BUILD_DATE: ${{ steps.setoutputs.outputs.builddate}}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -22,7 +25,7 @@ jobs:
         uses: docker/build-push-action@v4.0.0
         with:
           context: .
-          tags: ${{ env.REPO}}-${{ env.NOW }}:${{ env.TAG }}
+          tags: ${{ env.REPO_BASE}}-${{ env.NOW }}:${{ env.TAG }}
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -30,5 +33,36 @@ jobs:
           file: test/e2e/Dockerfile.e2e
           build-args: |
             TAG=${{ env.TAG }}
-            REPO=${{ env.REPO }}-${{ env.NOW }}
+            REPO=${{ env.REPO_BASE }}-${{ env.NOW }}
             COMMIT=${{ github.sha }}
+      - name: Set outputs
+        id: setoutputs
+        run: |
+          echo "repo=${{ env.REPO_BASE }}-${{ env.NOW }}" >> "$GITHUB_OUTPUT"
+          echo "builddate=${{ env.NOW }}" >> "$GITHUB_OUTPUT"
+  nightly_charts:
+    env:
+        REPO: ${{ needs.nightly_image.outputs.REPO }}
+        TAG: 1d
+        BUILD_DATE: ${{ needs.nightly_image.outputs.BUILD_DATE }}
+    runs-on: ubuntu-latest
+    needs: nightly_image
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+            fetch-depth: 0
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+            version: 'v3.12.1'
+      - name: Build charts
+        run: |
+          make charts
+        env:
+            CHART_VERSION: ${{ env.BUILD_DATE }}
+            GIT_TAG: ${{ env.BUILD_DATE }}
+      - name: Push charts
+        run: |
+          helm push bin/rancher-aks-operator-crd-${{ env.BUILD_DATE }}.tgz oci://ttl.sh/aks-operator
+          helm push bin/rancher-aks-operator-${{ env.BUILD_DATE }}.tgz oci://ttl.sh/aks-operator


### PR DESCRIPTION
This updates the nighlt GHA workflow so that it publishes the charts to ttl.sh so that they can be used for testing.