### PR TITLE
Adapt update-rancher-charts to support an empty release.yaml file

### DIFF
--- a/.github/scripts/update-rancher-charts.sh
+++ b/.github/scripts/update-rancher-charts.sh
@@ -30,20 +30,21 @@ fi
 find ./packages/rancher-aks-operator/ -type f -exec sed -i -e "s/${PREV_AKS_OPERATOR_VERSION}/${NEW_AKS_OPERATOR_VERSION}/g" {} \;
 find ./packages/rancher-aks-operator/ -type f -exec sed -i -e "s/version: ${PREV_CHART_VERSION}/version: ${NEW_CHART_VERSION}/g" {} \;
 
-if [ "${REPLACE}" == "true" ]; then
+if [ "${REPLACE}" == "true" ] && grep -q "rancher-aks-operator:" release.yaml; then
     sed -i -e "s/${PREV_CHART_VERSION}+up${PREV_AKS_OPERATOR_VERSION}/${NEW_CHART_VERSION}+up${NEW_AKS_OPERATOR_VERSION}/g" release.yaml
 else
-    sed -i -e "s/${PREV_CHART_VERSION}+up${PREV_AKS_OPERATOR_VERSION}/${PREV_CHART_VERSION}+up${PREV_AKS_OPERATOR_VERSION}\n  - ${NEW_CHART_VERSION}+up${NEW_AKS_OPERATOR_VERSION}/g" release.yaml
-    isChartPresent=$(cat release.yaml | grep -c "rancher-aks-operator:")
-    if [ $isChartPresent -eq 0 ]; then
-
-        cat <<< "rancher-aks-operator:
+    if grep -q "rancher-aks-operator:" release.yaml; then
+        sed -i -e "s/${PREV_CHART_VERSION}+up${PREV_AKS_OPERATOR_VERSION}/${PREV_CHART_VERSION}+up${PREV_AKS_OPERATOR_VERSION}\n  - ${NEW_CHART_VERSION}+up${NEW_AKS_OPERATOR_VERSION}/g" release.yaml
+    else
+        cat <<< "
+rancher-aks-operator:
 - ${PREV_CHART_VERSION}+up${PREV_AKS_OPERATOR_VERSION}
 - ${NEW_CHART_VERSION}+up${NEW_AKS_OPERATOR_VERSION}
 rancher-aks-operator-crd:
 - ${PREV_CHART_VERSION}+up${PREV_AKS_OPERATOR_VERSION}
 - ${NEW_CHART_VERSION}+up${NEW_AKS_OPERATOR_VERSION}" >> release.yaml
-
+    # remove empty line above rancher-aks-operator
+    sed -i -z -e  "s/[[:space:]]*\nrancher-aks-operator:/\nrancher-aks-operator:/g" release.yaml
     fi
 fi
 


### PR DESCRIPTION
### Description

When creating a PR against rancher/charts while releasing a new version of the operator, if `REPLACE=true` (e.g. bumping rc versions) and `release.yaml` in the charts repository is empty (this file is periodically cleaned), the workflow will not update the release file with the updated versions.

### Fix

This change adds an extra validation when `REPLACE=true`, and only tries to substitute versions if `release.yaml` already contains an entry for `rancher-aks-operator`. If it is not, it will populate the file treating it as empty.

This is equivalent to the change applied to `eks-operator` in https://github.com/rancher/eks-operator/pull/200.