### PR TITLE
Bump K8S version in e2e tests

### DIFF
--- a/test/e2e/templates/basic-cluster.yaml
+++ b/test/e2e/templates/basic-cluster.yaml
@@ -7,7 +7,7 @@ spec:
   clusterName: cluster
   dnsPrefix: basic-cluster-dns
   imported: false
-  kubernetesVersion: 1.25.5
+  kubernetesVersion: 1.26.6
   linuxAdminUsername: azureuser
   loadBalancerSku: Standard
   networkPlugin: kubenet
@@ -21,7 +21,7 @@ spec:
     maxPods: 110
     mode: System
     name: agentpool
-    orchestratorVersion: 1.25.5
+    orchestratorVersion: 1.26.6
     osDiskSizeGB: 30
     osDiskType: Managed
     osType: Linux


### PR DESCRIPTION
Bump K8S version in e2e tests, 1.25.5 is no longer supported by AKS