### PR TITLE
Improve dependabot conf to track other branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
   directory: "/"
   schedule:
       interval: "weekly"
-# Go
+# Go modules in main branch
 - package-ecosystem: "gomod"
   directory: "/"
   schedule:
@@ -18,4 +18,28 @@ updates:
   # together with controller-runtime.
   - dependency-name: "k8s.io/*"
   - dependency-name: "go.etcd.io/*"
-
+  target-branch: "main"
+# Go modules in release-v2.8 branch
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  ignore:
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+  # Ignore k8s and its transitives modules as they are upgraded manually
+  # together with controller-runtime.
+  - dependency-name: "k8s.io/*"
+  - dependency-name: "go.etcd.io/*"
+  target-branch: "release-v2.8"
+# Go modules in release-v2.7 branch
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  ignore:
+  - dependency-name: "sigs.k8s.io/controller-runtime"
+  # Ignore k8s and its transitives modules as they are upgraded manually
+  # together with controller-runtime.
+  - dependency-name: "k8s.io/*"
+  - dependency-name: "go.etcd.io/*"
+  target-branch: "release-v2.7"


### PR DESCRIPTION
**What this PR does / why we need it**:

We have to check outdated dependency also for `release-v2.8` and `release-v2.7` branches

**Which issue(s) this PR fixes**
Issue #

