### PR TITLE
🌱 Add azure-sdk-for-go dependency to dependabot ignore list in all branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,7 @@ updates:
   # together with controller-runtime.
   - dependency-name: "k8s.io/*"
   - dependency-name: "go.etcd.io/*"
+  - dependency-name: "github.com/Azure/azure-sdk-for-go"
   target-branch: "main"
 # Go modules in release-v2.8 branch
 - package-ecosystem: "gomod"
@@ -30,6 +31,7 @@ updates:
   # together with controller-runtime.
   - dependency-name: "k8s.io/*"
   - dependency-name: "go.etcd.io/*"
+  - dependency-name: "github.com/Azure/azure-sdk-for-go"
   target-branch: "release-v2.8"
 # Go modules in release-v2.7 branch
 - package-ecosystem: "gomod"
@@ -42,4 +44,5 @@ updates:
   # together with controller-runtime.
   - dependency-name: "k8s.io/*"
   - dependency-name: "go.etcd.io/*"
+  - dependency-name: "github.com/Azure/azure-sdk-for-go"
   target-branch: "release-v2.7"


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `azure-sdk-for-go` dependency to dependabot ignore list in all branches. We are intending to track bumping of that dependency in https://github.com/rancher/aks-operator/issues/287. Once #287 is completed, it can be removed from ignore list

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
