### PR TITLE
WIP: feat: deprecate NetworkDockerBridgeCIDR spec field

### DIFF
--- a/charts/aks-operator-crd/templates/crds.yaml
+++ b/charts/aks-operator-crd/templates/crds.yaml
@@ -45,9 +45,6 @@ spec:
               dnsServiceIp:
                 nullable: true
                 type: string
-              dockerBridgeCidr:
-                nullable: true
-                type: string
               httpApplicationRouting:
                 nullable: true
                 type: boolean

--- a/controller/aks-cluster-config-handler.go
+++ b/controller/aks-cluster-config-handler.go
@@ -460,9 +460,6 @@ func (h *Handler) validateConfig(config *aksv1.AKSClusterConfig) error {
 		if config.Spec.NetworkDNSServiceIP == nil {
 			return fmt.Errorf(cannotBeNilErrorAzurePlugin, "dnsServiceIp", config.Spec.ClusterName)
 		}
-		if config.Spec.NetworkDockerBridgeCIDR == nil {
-			return fmt.Errorf(cannotBeNilErrorAzurePlugin, "dockerBridgeCidr", config.Spec.ClusterName)
-		}
 		if config.Spec.NetworkServiceCIDR == nil {
 			return fmt.Errorf(cannotBeNilErrorAzurePlugin, "serviceCidr", config.Spec.ClusterName)
 		}
@@ -644,7 +641,6 @@ func (h *Handler) buildUpstreamClusterState(ctx context.Context, credentials *ak
 	if networkProfile != nil {
 		upstreamSpec.NetworkPlugin = to.StringPtr(string(networkProfile.NetworkPlugin))
 		upstreamSpec.NetworkDNSServiceIP = networkProfile.DNSServiceIP
-		upstreamSpec.NetworkDockerBridgeCIDR = networkProfile.DockerBridgeCidr
 		upstreamSpec.NetworkServiceCIDR = networkProfile.ServiceCidr
 		upstreamSpec.NetworkPolicy = to.StringPtr(string(networkProfile.NetworkPolicy))
 		upstreamSpec.NetworkPodCIDR = networkProfile.PodCidr

--- a/controller/aks-cluster-config-handler_test.go
+++ b/controller/aks-cluster-config-handler_test.go
@@ -253,13 +253,12 @@ var _ = Describe("validateConfig", func() {
 						OsType:       "test",
 					},
 				},
-				NetworkPlugin:           to.StringPtr(string(containerservice.Azure)),
-				NetworkPolicy:           to.StringPtr(string(containerservice.NetworkPolicyAzure)),
-				VirtualNetwork:          to.StringPtr("test"),
-				Subnet:                  to.StringPtr("test"),
-				NetworkDNSServiceIP:     to.StringPtr("test"),
-				NetworkDockerBridgeCIDR: to.StringPtr("test"),
-				NetworkServiceCIDR:      to.StringPtr("test"),
+				NetworkPlugin:       to.StringPtr(string(containerservice.Azure)),
+				NetworkPolicy:       to.StringPtr(string(containerservice.NetworkPolicyAzure)),
+				VirtualNetwork:      to.StringPtr("test"),
+				Subnet:              to.StringPtr("test"),
+				NetworkDNSServiceIP: to.StringPtr("test"),
+				NetworkServiceCIDR:  to.StringPtr("test"),
 			},
 		}
 
@@ -443,11 +442,6 @@ var _ = Describe("validateConfig", func() {
 		Expect(handler.validateConfig(aksConfig)).NotTo(Succeed())
 	})
 
-	It("should fail if network docker bridge cidr is empty", func() {
-		aksConfig.Spec.NetworkDockerBridgeCIDR = nil
-		Expect(handler.validateConfig(aksConfig)).NotTo(Succeed())
-	})
-
 	It("should fail if network pod cidr is empty", func() {
 		aksConfig.Spec.NetworkServiceCIDR = nil
 		Expect(handler.validateConfig(aksConfig)).NotTo(Succeed())
@@ -512,13 +506,12 @@ var _ = Describe("createCluster", func() {
 						OsType:       "test",
 					},
 				},
-				NetworkPlugin:           to.StringPtr(string(containerservice.Azure)),
-				NetworkPolicy:           to.StringPtr(string(containerservice.NetworkPolicyAzure)),
-				VirtualNetwork:          to.StringPtr("test"),
-				Subnet:                  to.StringPtr("test"),
-				NetworkDNSServiceIP:     to.StringPtr("test"),
-				NetworkDockerBridgeCIDR: to.StringPtr("test"),
-				NetworkServiceCIDR:      to.StringPtr("test"),
+				NetworkPlugin:       to.StringPtr(string(containerservice.Azure)),
+				NetworkPolicy:       to.StringPtr(string(containerservice.NetworkPolicyAzure)),
+				VirtualNetwork:      to.StringPtr("test"),
+				Subnet:              to.StringPtr("test"),
+				NetworkDNSServiceIP: to.StringPtr("test"),
+				NetworkServiceCIDR:  to.StringPtr("test"),
 			},
 		}
 
@@ -815,13 +808,12 @@ var _ = Describe("buildUpstreamClusterState", func() {
 					},
 				},
 				NetworkProfile: &containerservice.NetworkProfile{
-					NetworkPlugin:    containerservice.Azure,
-					DNSServiceIP:     to.StringPtr("test"),
-					DockerBridgeCidr: to.StringPtr("test"),
-					ServiceCidr:      to.StringPtr("test"),
-					NetworkPolicy:    containerservice.NetworkPolicyAzure,
-					PodCidr:          to.StringPtr("test"),
-					LoadBalancerSku:  containerservice.Standard,
+					NetworkPlugin:   containerservice.Azure,
+					DNSServiceIP:    to.StringPtr("test"),
+					ServiceCidr:     to.StringPtr("test"),
+					NetworkPolicy:   containerservice.NetworkPolicyAzure,
+					PodCidr:         to.StringPtr("test"),
+					LoadBalancerSku: containerservice.Standard,
 				},
 				LinuxProfile: &containerservice.LinuxProfile{
 					AdminUsername: to.StringPtr("test"),
@@ -890,7 +882,6 @@ var _ = Describe("buildUpstreamClusterState", func() {
 		Expect(upstreamSpec.NodePools[0].MaxSurge).To(Equal(nodePools[0].UpgradeSettings.MaxSurge))
 		Expect(upstreamSpec.NetworkPlugin).To(Equal(to.StringPtr(string(clusterState.NetworkProfile.NetworkPlugin))))
 		Expect(upstreamSpec.NetworkDNSServiceIP).To(Equal(clusterState.NetworkProfile.DNSServiceIP))
-		Expect(upstreamSpec.NetworkDockerBridgeCIDR).To(Equal(clusterState.NetworkProfile.DockerBridgeCidr))
 		Expect(upstreamSpec.NetworkServiceCIDR).To(Equal(clusterState.NetworkProfile.ServiceCidr))
 		Expect(upstreamSpec.NetworkPolicy).To(Equal(to.StringPtr(string(clusterState.NetworkProfile.NetworkPolicy))))
 		Expect(upstreamSpec.NetworkPodCIDR).To(Equal(clusterState.NetworkProfile.PodCidr))

--- a/pkg/aks/create.go
+++ b/pkg/aks/create.go
@@ -134,7 +134,6 @@ func createManagedCluster(ctx context.Context, cred *Credentials, workplacesClie
 		}
 
 		networkProfile.DNSServiceIP = spec.NetworkDNSServiceIP
-		networkProfile.DockerBridgeCidr = spec.NetworkDockerBridgeCIDR
 		networkProfile.ServiceCidr = spec.NetworkServiceCIDR
 		networkProfile.PodCidr = spec.NetworkPodCIDR
 	}

--- a/pkg/aks/create_test.go
+++ b/pkg/aks/create_test.go
@@ -98,7 +98,6 @@ var _ = Describe("newManagedCluster", func() {
 		Expect(managedCluster.NetworkProfile.LoadBalancerSku).To(Equal(containerservice.LoadBalancerSku(to.String(clusterSpec.LoadBalancerSKU))))
 		Expect(managedCluster.NetworkProfile.NetworkPlugin).To(Equal(containerservice.NetworkPlugin(to.String(clusterSpec.NetworkPlugin))))
 		Expect(managedCluster.NetworkProfile.DNSServiceIP).To(Equal(clusterSpec.NetworkDNSServiceIP))
-		Expect(managedCluster.NetworkProfile.DockerBridgeCidr).To(Equal(clusterSpec.NetworkDockerBridgeCIDR))
 		Expect(managedCluster.NetworkProfile.ServiceCidr).To(Equal(clusterSpec.NetworkServiceCIDR))
 		Expect(managedCluster.NetworkProfile.PodCidr).To(Equal(clusterSpec.NetworkPodCIDR))
 		Expect(managedCluster.NetworkProfile.OutboundType).To(Equal(containerservice.LoadBalancer))
@@ -184,7 +183,6 @@ var _ = Describe("newManagedCluster", func() {
 		clusterSpec.NetworkPlugin = to.StringPtr("kubenet")
 		clusterSpec.NetworkPolicy = to.StringPtr("calico")
 		clusterSpec.NetworkDNSServiceIP = to.StringPtr("")
-		clusterSpec.NetworkDockerBridgeCIDR = to.StringPtr("")
 		clusterSpec.NetworkServiceCIDR = to.StringPtr("")
 		clusterSpec.NetworkPodCIDR = to.StringPtr("")
 
@@ -192,7 +190,6 @@ var _ = Describe("newManagedCluster", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(managedCluster.NetworkProfile.NetworkPlugin).To(Equal(containerservice.Kubenet))
 		Expect(managedCluster.NetworkProfile.DNSServiceIP).To(Equal(clusterSpec.NetworkDNSServiceIP))
-		Expect(managedCluster.NetworkProfile.DockerBridgeCidr).To(Equal(clusterSpec.NetworkDockerBridgeCIDR))
 		Expect(managedCluster.NetworkProfile.ServiceCidr).To(Equal(clusterSpec.NetworkServiceCIDR))
 		Expect(managedCluster.NetworkProfile.PodCidr).To(Equal(clusterSpec.NetworkPodCIDR))
 	})
@@ -208,7 +205,6 @@ var _ = Describe("newManagedCluster", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(managedCluster.NetworkProfile.NetworkPlugin).To(Equal(containerservice.Kubenet))
 		Expect(managedCluster.NetworkProfile.DNSServiceIP).To(Equal(clusterSpec.NetworkDNSServiceIP))
-		Expect(managedCluster.NetworkProfile.DockerBridgeCidr).To(Equal(clusterSpec.NetworkDockerBridgeCIDR))
 		Expect(managedCluster.NetworkProfile.ServiceCidr).To(Equal(clusterSpec.NetworkServiceCIDR))
 		Expect(managedCluster.NetworkProfile.PodCidr).To(Equal(clusterSpec.NetworkPodCIDR))
 	})
@@ -498,15 +494,14 @@ func newTestClusterSpec() *aksv1.AKSClusterConfigSpec {
 		Tags: map[string]string{
 			"test-tag": "test-value",
 		},
-		NetworkPolicy:           to.StringPtr("azure"),
-		NetworkPlugin:           to.StringPtr("azure"),
-		NetworkDNSServiceIP:     to.StringPtr("test-dns-service-ip"),
-		NetworkDockerBridgeCIDR: to.StringPtr("test-docker-bridge-cidr"),
-		NetworkServiceCIDR:      to.StringPtr("test-service-cidr"),
-		NetworkPodCIDR:          to.StringPtr("test-pod-cidr"),
-		ResourceGroup:           "test-rg",
-		VirtualNetwork:          to.StringPtr("test-virtual-network"),
-		Subnet:                  to.StringPtr("test-subnet"),
+		NetworkPolicy:       to.StringPtr("azure"),
+		NetworkPlugin:       to.StringPtr("azure"),
+		NetworkDNSServiceIP: to.StringPtr("test-dns-service-ip"),
+		NetworkServiceCIDR:  to.StringPtr("test-service-cidr"),
+		NetworkPodCIDR:      to.StringPtr("test-pod-cidr"),
+		ResourceGroup:       "test-rg",
+		VirtualNetwork:      to.StringPtr("test-virtual-network"),
+		Subnet:              to.StringPtr("test-subnet"),
 		NodePools: []aksv1.AKSNodePool{
 			{
 				Name:                to.StringPtr("test-node-pool"),

--- a/pkg/aks/update.go
+++ b/pkg/aks/update.go
@@ -122,9 +122,6 @@ func updateCluster(desiredCluster containerservice.ManagedCluster, actualCluster
 		if desiredCluster.NetworkProfile.DNSServiceIP != nil {
 			actualCluster.NetworkProfile.DNSServiceIP = desiredCluster.NetworkProfile.DNSServiceIP
 		}
-		if desiredCluster.NetworkProfile.DockerBridgeCidr != nil {
-			actualCluster.NetworkProfile.DockerBridgeCidr = desiredCluster.NetworkProfile.DockerBridgeCidr
-		}
 		if desiredCluster.NetworkProfile.PodCidr != nil {
 			actualCluster.NetworkProfile.PodCidr = desiredCluster.NetworkProfile.PodCidr
 		}

--- a/pkg/aks/update_test.go
+++ b/pkg/aks/update_test.go
@@ -38,16 +38,15 @@ var _ = Describe("updateCluster", func() {
 					},
 				},
 			},
-			AuthorizedIPRanges:      to.StringSlicePtr([]string{"test-ip-range"}),
-			LinuxAdminUsername:      to.StringPtr("test-admin-username"),
-			LinuxSSHPublicKey:       to.StringPtr("test-ssh-public-key"),
-			NetworkPlugin:           to.StringPtr("azure"),
-			NetworkPolicy:           to.StringPtr("azure"),
-			NetworkDNSServiceIP:     to.StringPtr("test-dns-service-ip"),
-			NetworkDockerBridgeCIDR: to.StringPtr("test-docker-bridge-cidr"),
-			NetworkPodCIDR:          to.StringPtr("test-pod-cidr"),
-			NetworkServiceCIDR:      to.StringPtr("test-service-cidr"),
-			LoadBalancerSKU:         to.StringPtr("standard"),
+			AuthorizedIPRanges:  to.StringSlicePtr([]string{"test-ip-range"}),
+			LinuxAdminUsername:  to.StringPtr("test-admin-username"),
+			LinuxSSHPublicKey:   to.StringPtr("test-ssh-public-key"),
+			NetworkPlugin:       to.StringPtr("azure"),
+			NetworkPolicy:       to.StringPtr("azure"),
+			NetworkDNSServiceIP: to.StringPtr("test-dns-service-ip"),
+			NetworkPodCIDR:      to.StringPtr("test-pod-cidr"),
+			NetworkServiceCIDR:  to.StringPtr("test-service-cidr"),
+			LoadBalancerSKU:     to.StringPtr("standard"),
 			Tags: map[string]string{
 				"test-tag": "test-value",
 			},
@@ -100,7 +99,6 @@ var _ = Describe("updateCluster", func() {
 		Expect(updatedCluster.NetworkProfile.NetworkPlugin).To(Equal(containerservice.Azure))
 		Expect(updatedCluster.NetworkProfile.NetworkPolicy).To(Equal(containerservice.NetworkPolicyAzure))
 		Expect(updatedCluster.NetworkProfile.DNSServiceIP).To(Equal(clusterSpec.NetworkDNSServiceIP))
-		Expect(updatedCluster.NetworkProfile.DockerBridgeCidr).To(Equal(clusterSpec.NetworkDockerBridgeCIDR))
 		Expect(updatedCluster.NetworkProfile.PodCidr).To(Equal(clusterSpec.NetworkPodCIDR))
 		Expect(updatedCluster.NetworkProfile.ServiceCidr).To(Equal(clusterSpec.NetworkServiceCIDR))
 		Expect(updatedCluster.NetworkProfile.LoadBalancerSku).To(Equal(containerservice.Standard))

--- a/pkg/apis/aks.cattle.io/v1/types.go
+++ b/pkg/apis/aks.cattle.io/v1/types.go
@@ -77,8 +77,6 @@ type AKSClusterConfigSpec struct {
 	NetworkDNSServiceIP *string `json:"dnsServiceIp" norman:"pointer"`
 	// NetworkService CIDR is the network service cidr.
 	NetworkServiceCIDR *string `json:"serviceCidr" norman:"pointer"`
-	// NetworkDockerBridgeCIDR is the network docker bridge cidr.
-	NetworkDockerBridgeCIDR *string `json:"dockerBridgeCidr" norman:"pointer"`
 	// NetworkPodCIDR is the network pod cidr.
 	NetworkPodCIDR *string `json:"podCidr" norman:"pointer"`
 	// NodeResourceGroupName is the name of the resource group

--- a/pkg/apis/aks.cattle.io/v1/zz_generated_deepcopy.go
+++ b/pkg/apis/aks.cattle.io/v1/zz_generated_deepcopy.go
@@ -129,11 +129,6 @@ func (in *AKSClusterConfigSpec) DeepCopyInto(out *AKSClusterConfigSpec) {
 		*out = new(string)
 		**out = **in
 	}
-	if in.NetworkDockerBridgeCIDR != nil {
-		in, out := &in.NetworkDockerBridgeCIDR, &out.NetworkDockerBridgeCIDR
-		*out = new(string)
-		**out = **in
-	}
 	if in.NetworkPodCIDR != nil {
 		in, out := &in.NetworkPodCIDR, &out.NetworkPodCIDR
 		*out = new(string)


### PR DESCRIPTION
**What this PR does / why we need it**:

As reported by QA, the Docker Bridge CIDR field is now [deprecated in the AKS API](https://github.com/Azure/AKS/releases/tag/2023-05-07) as it was made redundant when AKS changed from Docker to ContainerD. This PR removes the corresponding field from the cluster specification.

**Which issue(s) this PR fixes**
Issue #248 

**Special notes for your reviewer**:

This change requires the removal of the field box from the UI.

**It must adhere to our deprecation policy.**

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
