### PR TITLE
🌱 Use unrc'd version of rancher in e2e tests

### DIFF
--- a/test/e2e/config/config.yaml
+++ b/test/e2e/config/config.yaml
@@ -8,5 +8,5 @@ artifactsDir: ../../_artifacts
 certManagerVersion: v1.9.2
 certManagerChartURL: https://charts.jetstack.io/charts/cert-manager-${CERT_MANAGER_VERSION}.tgz
 
-rancherVersion: 2.7.5-rc5
+rancherVersion: 2.7.9
 rancherChartURL: https://releases.rancher.com/server-charts/latest/rancher-${RANCHER_VERSION}.tgz


### PR DESCRIPTION
**What this PR does / why we need it**: 
v2.7.5 is recommended to be skipped as per by [release notes](https://github.com/rancher/rancher/releases/tag/v2.7.5 ), so bumping it to use proper patch version of rancher v2.7.9 https://github.com/rancher/rancher/releases/tag/v2.7.9.

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [x] adds or updates e2e tests
- [ ] backport needed 
