### PR TITLE
chore: add dependabot ignore for rancher/wrangler

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,18 +7,25 @@ updates:
   directory: "/"
   schedule:
       interval: "weekly"
+  commit-message:
+    prefix: ":seedling:"
 # Go modules in main branch
 - package-ecosystem: "gomod"
   directory: "/"
   schedule:
     interval: "weekly"
   ignore:
-  - dependency-name: "sigs.k8s.io/controller-runtime"
-  # Ignore k8s and its transitives modules as they are upgraded manually
-  # together with controller-runtime.
-  - dependency-name: "k8s.io/*"
-  - dependency-name: "go.etcd.io/*"
-  - dependency-name: "github.com/Azure/azure-sdk-for-go"
+    # Ignore controller-runtime as it's upgraded manually.
+    - dependency-name: "sigs.k8s.io/controller-runtime"
+    # Ignore k8s and its transitives modules as they are upgraded manually
+    # together with controller-runtime.
+    - dependency-name: "k8s.io/*"
+    # Ignore wrangler
+    - dependency-name: "github.com/rancher/wrangler"
+    - dependency-name: "go.etcd.io/*"
+    - dependency-name: "github.com/Azure/azure-sdk-for-go"
+  commit-message:
+    prefix: ":seedling:"
   target-branch: "main"
 # Go modules in release-v2.8 branch
 - package-ecosystem: "gomod"
@@ -26,12 +33,17 @@ updates:
   schedule:
     interval: "weekly"
   ignore:
-  - dependency-name: "sigs.k8s.io/controller-runtime"
-  # Ignore k8s and its transitives modules as they are upgraded manually
-  # together with controller-runtime.
-  - dependency-name: "k8s.io/*"
-  - dependency-name: "go.etcd.io/*"
-  - dependency-name: "github.com/Azure/azure-sdk-for-go"
+    # Ignore controller-runtime as it's upgraded manually.
+    - dependency-name: "sigs.k8s.io/controller-runtime"
+    # Ignore k8s and its transitives modules as they are upgraded manually
+    # together with controller-runtime.
+    - dependency-name: "k8s.io/*"
+    # Ignore wrangler
+    - dependency-name: "github.com/rancher/wrangler"
+    - dependency-name: "go.etcd.io/*"
+    - dependency-name: "github.com/Azure/azure-sdk-for-go"
+  commit-message:
+    prefix: ":seedling:"
   target-branch: "release-v2.8"
 # Go modules in release-v2.7 branch
 - package-ecosystem: "gomod"
@@ -39,10 +51,15 @@ updates:
   schedule:
     interval: "weekly"
   ignore:
-  - dependency-name: "sigs.k8s.io/controller-runtime"
-  # Ignore k8s and its transitives modules as they are upgraded manually
-  # together with controller-runtime.
-  - dependency-name: "k8s.io/*"
-  - dependency-name: "go.etcd.io/*"
-  - dependency-name: "github.com/Azure/azure-sdk-for-go"
+    # Ignore controller-runtime as it's upgraded manually.
+    - dependency-name: "sigs.k8s.io/controller-runtime"
+    # Ignore k8s and its transitives modules as they are upgraded manually
+    # together with controller-runtime.
+    - dependency-name: "k8s.io/*"
+    # Ignore wrangler
+    - dependency-name: "github.com/rancher/wrangler"
+    - dependency-name: "go.etcd.io/*"
+    - dependency-name: "github.com/Azure/azure-sdk-for-go"
   target-branch: "release-v2.7"
+  commit-message:
+    prefix: ":seedling:"


### PR DESCRIPTION
**What this PR does / why we need it**:

Dependabot should ignore `rancher/wrangler` version bumps as it is updated manually. This change also aligns `dependabot.yml`'s format with other providers (refer to `gke-operator` [here](https://github.com/rancher/gke-operator/blob/main/.github/dependabot.yaml)).

**Which issue(s) this PR fixes**
Issue #357 

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
