### PR TITLE
chore: bump apidiff.yaml go version

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -10,5 +10,5 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v5
       with:
-        go-version: 1.18
+        go-version: 1.20.x
     - uses: joelanford/go-apidiff@main


### PR DESCRIPTION
**What this PR does / why we need it**:

For the last couple of days we've had [API diff validation workflow failing on new PRs](https://github.com/rancher/aks-operator/actions/runs/7534808581/job/20509794469?pr=355).

After some investigation, it looks like this matches `joelanford/go-apidiff`'s new [release](https://github.com/joelanford/go-apidiff/releases). As we're using the latest version [here](https://github.com/rancher/aks-operator/blob/ba933df3b5b5fc12bb8a13963ae301f878af0c59/.github/workflows/apidiff.yaml#L14), CI is failing because our workflow is configured to use Go 1.18 while this new API diff action requires >=1.19.

This PR updates the workflow's Go version to match the project's (Go 1.20).

**Which issue(s) this PR fixes**
Issue #359 

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
