### PR TITLE
chore: bump apidiff.yaml go version

### DIFF
--- a/.github/workflows/apidiff.yaml
+++ b/.github/workflows/apidiff.yaml
@@ -10,5 +10,5 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v4
       with:
-        go-version: 1.18
+        go-version: 1.20.x
     - uses: joelanford/go-apidiff@main


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport `apidiff.yaml` Go version update to `release-v2.8` to avoid PR CI failures (e.g. https://github.com/rancher/aks-operator/pull/355).

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
