### PR TITLE
Dependabot ignore wrangler version main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,25 @@ updates:
   commit-message:
     prefix: ":seedling:"
   target-branch: "main"
+# Go modules in release-v2.9 branch
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  ignore:
+    # Ignore controller-runtime as it's upgraded manually.
+    - dependency-name: "sigs.k8s.io/controller-runtime"
+    # Ignore k8s and its transitives modules as they are upgraded manually
+    # together with controller-runtime.
+    - dependency-name: "k8s.io/*"
+    # Ignore wrangler
+    - dependency-name: "github.com/rancher/wrangler"
+    - dependency-name: "github.com/rancher/wrangler/v2"
+    - dependency-name: "go.etcd.io/*"
+    - dependency-name: "github.com/Azure/azure-sdk-for-go"
+  commit-message:
+    prefix: ":seedling:"
+  target-branch: "release-v2.9"
 # Go modules in release-v2.8 branch
 - package-ecosystem: "gomod"
   directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
     - dependency-name: "k8s.io/*"
     # Ignore wrangler
     - dependency-name: "github.com/rancher/wrangler"
+    - dependency-name: "github.com/rancher/wrangler/v2"
     - dependency-name: "go.etcd.io/*"
     - dependency-name: "github.com/Azure/azure-sdk-for-go"
   commit-message:
@@ -40,6 +41,7 @@ updates:
     - dependency-name: "k8s.io/*"
     # Ignore wrangler
     - dependency-name: "github.com/rancher/wrangler"
+    - dependency-name: "github.com/rancher/wrangler/v2"
     - dependency-name: "go.etcd.io/*"
     - dependency-name: "github.com/Azure/azure-sdk-for-go"
   commit-message:
@@ -58,6 +60,7 @@ updates:
     - dependency-name: "k8s.io/*"
     # Ignore wrangler
     - dependency-name: "github.com/rancher/wrangler"
+    - dependency-name: "github.com/rancher/wrangler/v2"
     - dependency-name: "go.etcd.io/*"
     - dependency-name: "github.com/Azure/azure-sdk-for-go"
   target-branch: "release-v2.7"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add rule for dependabot to ignore wrangler updates and a new block for `release-v2.9`.

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
