### PR TITLE
[v2.7] security: bump operator base image to bci-micro:15.5 

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.4
+FROM registry.suse.com/bci/bci-base:15.6
 
 ARG DAPPER_HOST_ARCH
 ENV ARCH=${DAPPER_HOST_ARCH}

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,8 +1,13 @@
-FROM registry.suse.com/bci/bci-base:15.4
-RUN zypper update -y && \
-    zypper -n clean -a && \
-    rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*
+FROM registry.suse.com/bci/bci-base:15.5 AS builder
+RUN sed -i 's/^CREATE_MAIL_SPOOL=yes/CREATE_MAIL_SPOOL=no/' /etc/default/useradd
 RUN useradd --uid 1007 aks-operator
+
+FROM registry.suse.com/bci/bci-micro:15.5
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/shadow /etc/shadow
+
+RUN rm -rf /tmp/* /var/tmp/* /usr/share/doc/packages/*
+
 ENV KUBECONFIG /home/aks-operator/.kube/config
 ENV SSL_CERT_DIR /etc/rancher/ssl
 


### PR DESCRIPTION
Issue: https://github.com/rancher/aks-operator/issues/427 (cherry picked from commit 31fe83bfc7725e8ce8407853d5958135a6a8d883)

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
