### PR TITLE
fix: Bump version of k8s used for e2e test

### DIFF
--- a/test/e2e/templates/basic-cluster.yaml
+++ b/test/e2e/templates/basic-cluster.yaml
@@ -7,7 +7,7 @@ spec:
   clusterName: cluster
   dnsPrefix: basic-cluster-dns
   imported: false
-  kubernetesVersion: 1.26.10
+  kubernetesVersion: 1.28.9
   linuxAdminUsername: azureuser
   loadBalancerSku: Standard
   networkPlugin: kubenet
@@ -21,7 +21,7 @@ spec:
     maxPods: 110
     mode: System
     name: agentpool
-    orchestratorVersion: 1.26.10
+    orchestratorVersion: 1.28.9
     osDiskSizeGB: 30
     osDiskType: Managed
     osType: Linux


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Bump version of k8s used for e2e test. 1.26.10 is no longer supported in AKS in the eastus region.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
