### PR TITLE
[v2.9] fix: Use v2.9-head version of Rancher for e2e tests

### DIFF
--- a/test/e2e/config/config.yaml
+++ b/test/e2e/config/config.yaml
@@ -8,5 +8,5 @@ artifactsDir: ../../_artifacts
 certManagerVersion: v1.9.2
 certManagerChartURL: https://charts.jetstack.io/charts/cert-manager-${CERT_MANAGER_VERSION}.tgz
 
-rancherVersion: 2.7.9
+rancherVersion: v2.9-head
 rancherChartURL: https://releases.rancher.com/server-charts/latest/rancher-${RANCHER_VERSION}.tgz


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Use v2.9-head version of Rancher for e2e tests.

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
