### PR TITLE
[v2.8] fix: Use version v2.8-head of Rancher for e2e tests 

### DIFF
--- a/test/e2e/config/config.yaml
+++ b/test/e2e/config/config.yaml
@@ -8,5 +8,5 @@ artifactsDir: ../../_artifacts
 certManagerVersion: v1.9.2
 certManagerChartURL: https://charts.jetstack.io/charts/cert-manager-${CERT_MANAGER_VERSION}.tgz
 
-rancherVersion: 2.7.5-rc5
-rancherChartURL: https://releases.rancher.com/server-charts/latest/rancher-${RANCHER_VERSION}.tgz
+rancherVersion: v2.8-head
+rancherChartURL: https://releases.rancher.com/server-charts/latest/

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -111,7 +111,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Deploying rancher and cert-manager", func() {
-		By("installing cert-manager", func() {
+		By("Installing cert-manager", func() {
 			if isDeploymentReady(certManagerNamespace, certManagerName) {
 				By("already installed")
 			} else {
@@ -134,14 +134,31 @@ var _ = BeforeSuite(func() {
 			}
 		})
 
-		By("installing rancher", func() {
+		By("Add rancher helm chart repository", func() {
+			Expect(kubectl.RunHelmBinaryWithCustomErr(
+				"repo",
+				"add",
+				"--force-update",
+				"rancher-latest",
+				fmt.Sprintf(e2eCfg.RancherChartURL),
+			)).To(Succeed())
+		})
+
+		By("Update helm repositories", func() {
+			Expect(kubectl.RunHelmBinaryWithCustomErr(
+				"repo",
+				"update",
+			)).To(Succeed())
+		})
+
+		By("Installing rancher", func() {
 			if isDeploymentReady(cattleSystemNamespace, rancherName) {
 				By("already installed")
 			} else {
 				Expect(kubectl.RunHelmBinaryWithCustomErr(
+					"install",
 					"-n",
 					cattleSystemNamespace,
-					"install",
 					"--set",
 					"bootstrapPassword=admin",
 					"--set",
@@ -154,8 +171,9 @@ var _ = BeforeSuite(func() {
 					"global.cattle.psp.enabled=false",
 					"--set", fmt.Sprintf("hostname=%s.%s", e2eCfg.ExternalIP, e2eCfg.MagicDNS),
 					"--create-namespace",
+					"--set", fmt.Sprintf("rancherImageTag=%s", e2eCfg.RancherVersion),
 					rancherName,
-					fmt.Sprintf(e2eCfg.RancherChartURL),
+					"rancher-latest/rancher",
 				)).To(Succeed())
 				Eventually(func() bool {
 					return isDeploymentReady(cattleSystemNamespace, rancherName)


### PR DESCRIPTION

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

This PR updates the e2e tests for `release-v2.8` to use the latest Rancher Helm chart (currently `2.8.5`) and overrides the image tag with `v2.8-head`


**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
