### PR TITLE
[v2.9] Fix logic for Authorized IP ranges

### DIFF
--- a/controller/aks-cluster-config-handler.go
+++ b/controller/aks-cluster-config-handler.go
@@ -698,6 +698,7 @@ func (h *Handler) buildUpstreamClusterState(ctx context.Context, credentials *ak
 
 	// set API server access profile
 	upstreamSpec.PrivateCluster = to.Ptr(false)
+	upstreamSpec.AuthorizedIPRanges = utils.ConvertToPointerOfSlice([]*string{})
 	if clusterState.Properties.APIServerAccessProfile != nil {
 		if clusterState.Properties.APIServerAccessProfile.EnablePrivateCluster != nil {
 			upstreamSpec.PrivateCluster = clusterState.Properties.APIServerAccessProfile.EnablePrivateCluster


### PR DESCRIPTION
Fix logic for updating Authorized IP ranges:
- all settings should be overwrite for AKS clusters provisioned by Rancher
- for imported clusters options should be merged with downstream cluster

Issue: https://github.com/rancher/aks-operator/issues/592

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes**
Issue #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
