### PR TITLE
ci: Specify the exact tag for the new release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,6 +55,7 @@ jobs:
     - name: Create release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # required for creating GH release
+        GORELEASER_CURRENT_TAG: ${{ github.ref_name }} # specify the tag to be released
       id: goreleaser
       uses: goreleaser/goreleaser-action@v6
       with:


### PR DESCRIPTION


<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Specify the exact tag for the new release. This is necessary because by default, goreleaser sorts tags by name before selecting which tag to release, which causes problems when >1 tags point to the same commit (un-rc process).  From https://goreleaser.com/cookbooks/set-a-custom-git-tag/

**Which issue(s) this PR fixes**
Issue #596 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
