### PR TITLE
fix: Disable monitoring addon when spec.Monitoring is false

### DIFF
--- a/controller/aks-cluster-config-handler_test.go
+++ b/controller/aks-cluster-config-handler_test.go
@@ -937,4 +937,21 @@ var _ = Describe("buildUpstreamClusterState", func() {
 		_, err := handler.buildUpstreamClusterState(ctx, credentials, &aksConfig.Spec)
 		Expect(err).ToNot(HaveOccurred())
 	})
+
+	It("should succeed even if the monitoring addon is disabled", func() {
+		clusterState.Properties.AddonProfiles["omsAgent"] = &armcontainerservice.ManagedClusterAddonProfile{
+			Enabled: to.Ptr(false),
+			Config:  nil,
+		}
+		clusterClientMock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), nil).Return(
+			armcontainerservice.ManagedClustersClientGetResponse{
+				ManagedCluster: *clusterState,
+			}, nil)
+
+		upstreamSpec, err := handler.buildUpstreamClusterState(ctx, credentials, &aksConfig.Spec)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(*upstreamSpec.Monitoring).To(BeFalse())
+		Expect(upstreamSpec.LogAnalyticsWorkspaceGroup).To(BeNil())
+		Expect(upstreamSpec.LogAnalyticsWorkspaceGroup).To(BeNil())
+	})
 })

--- a/pkg/aks/create.go
+++ b/pkg/aks/create.go
@@ -224,7 +224,8 @@ func createManagedCluster(ctx context.Context, cred *Credentials, workplacesClie
 	}
 
 	// Get monitoring from config spec
-	if Bool(spec.Monitoring) {
+	if spec.Monitoring != nil && Bool(spec.Monitoring) {
+		logrus.Debug("Monitoring is enabled")
 		managedCluster.Properties.AddonProfiles["omsAgent"] = &armcontainerservice.ManagedClusterAddonProfile{
 			Enabled: spec.Monitoring,
 		}
@@ -242,6 +243,12 @@ func createManagedCluster(ctx context.Context, cred *Credentials, workplacesClie
 
 		managedCluster.Properties.AddonProfiles["omsAgent"].Config = map[string]*string{
 			"logAnalyticsWorkspaceResourceID": to.Ptr(logAnalyticsWorkspaceResourceID),
+		}
+	} else if spec.Monitoring != nil && !Bool(spec.Monitoring) {
+		logrus.Debug("Monitoring is disabled")
+		managedCluster.Properties.AddonProfiles["omsAgent"] = &armcontainerservice.ManagedClusterAddonProfile{
+			Enabled: spec.Monitoring,
+			Config:  nil,
 		}
 	}
 

--- a/pkg/aks/create_test.go
+++ b/pkg/aks/create_test.go
@@ -334,7 +334,18 @@ var _ = Describe("newManagedCluster", func() {
 		managedCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "test-phase")
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(managedCluster.Properties.AddonProfiles).ToNot(HaveKey("omsagent"))
+		Expect(managedCluster.Properties.AddonProfiles).ToNot(HaveKey("omsAgent"))
+	})
+
+	It("should successfully create managed cluster with monitoring disabled", func() {
+		workplacesClientMock.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(armoperationalinsights.WorkspacesClientGetResponse{}, nil).Times(0)
+		flag := false
+		clusterSpec.Monitoring = &flag
+		managedCluster, err := createManagedCluster(ctx, cred, workplacesClientMock, clusterSpec, "test-phase")
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(managedCluster.Properties.AddonProfiles).To(HaveKey("omsAgent"))
+		Expect(*managedCluster.Properties.AddonProfiles["omsAgent"].Enabled).To(BeFalse())
 	})
 
 	It("should successfully create managed cluster when phase is set to active", func() {


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

The monitoring addon was not being disabled as per the spec.

**Which issue(s) this PR fixes**
Issue #584 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
- [x] backport needed 
