### PR TITLE
[2.9] ci: Split image publishing from creating GH release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,10 +16,10 @@ on:
 #   - PUBLIC_REGISTRY_PASSWORD
 
 jobs:
-  release:
+  publish-images:
     permissions:
-      contents: write # required for creating GH release
-      id-token: write # required for reading vault secrets
+      contents: read
+      id-token: write # required for reading vault secrets and for cosign's use in ecm-distro-tools/publish-image
     strategy:
       matrix:
         include:
@@ -67,6 +67,18 @@ jobs:
         push-to-prime: false
     - name: Cleanup checksum files # in order to avoid goreleaser dirty state error, remove once rancher/ecm-distro-tools/actions/publish-image@main gets updated
       run: rm -f slsactl_*_checksums.txt*
+
+  release:
+    permissions:
+      contents: write # required for creating GH release
+    runs-on: ubuntu-latest
+    needs: publish-images
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ github.ref_name}}
     - name: Create release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # required for creating GH release


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

Split the image publishing step from the GH release creation step. The reason is that since we now use a matrix to publish images, we don't want the GH release creation step to run multiple times, just once.

**Which issue(s) this PR fixes**
Issue #748 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
