### PR TITLE
[v2.10] ci: Fix repo name in values.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -90,7 +90,7 @@ jobs:
     - name: Upload charts to release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # required for updating GH release
-        REPO: rancher/aks-operator # Docker repository to reference in `values.yaml` of the Helm chart release
+        REPO: rancher # First name component for Docker repository to reference in `values.yaml` of the Helm chart release, this is expected to be `rancher`, image name is appended to this value
         TAG: ${{ github.ref_name }} # image tag to be referenced in `values.yaml` of the Helm chart release
       run: |
         version=$(echo '${{ steps.goreleaser.outputs.metadata }}' | jq -r '.version')


### PR DESCRIPTION
<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

A previous change in the Makefile resulted in the image name being generated to be `rancher/aks-operator/aks-operator` instead of `rancher/aks-operator`. This PR addresses this.


**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
