### PR TITLE
[2.10] fix: Print build commit SHA during startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rancher/aks-operator/controller"
 	aksv1 "github.com/rancher/aks-operator/pkg/generated/controllers/aks.cattle.io"
+	"github.com/rancher/aks-operator/pkg/version"
 	core3 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core"
 	"github.com/rancher/wrangler/v3/pkg/kubeconfig"
 	"github.com/rancher/wrangler/v3/pkg/signals"
@@ -36,6 +37,7 @@ func main() {
 		logrus.SetLevel(logrus.DebugLevel)
 		logrus.Debugf("Loglevel set to [%v]", logrus.DebugLevel)
 	}
+	logrus.Infof("Starting aks-operator (version: %s, commit: %s)", version.Version, version.GitCommit)
 
 	// This will load the kubeconfig file in a style the same as kubectl
 	cfg, err := kubeconfig.GetNonInteractiveClientConfig(kubeconfigFile).ClientConfig()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,6 @@
+package version
+
+var (
+	GitCommit string
+	Version   string
+)


### PR DESCRIPTION
(cherry picked from commit 472dc2a7dfc30ebc452691937def1e2eae793f02)

<!--
Label the PR with the kind of change this for:

kind/feature
kind/bug
kind/documentation
kind/regression
kind/*
-->

**What this PR does / why we need it**:

As part of https://github.com/rancher/aks-operator/pull/804 we already pass version and git sha information during go build. This PR outputs this information when the operator starts to assist with troubleshooting.

**Which issue(s) this PR fixes**
Issue #726 

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
- [ ] backport needed 
