### PR TITLE
[main] handle conflict errors while updating aksClusterConfig

### DIFF
--- a/controller/aks-cluster-config-handler_test.go
+++ b/controller/aks-cluster-config-handler_test.go
@@ -1,7 +1,9 @@
 package controller
 
 import (
+	"bytes"
 	"errors"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v5"
@@ -15,6 +17,7 @@ import (
 	"github.com/rancher/aks-operator/pkg/test"
 	"github.com/rancher/aks-operator/pkg/utils"
 	"github.com/rancher/wrangler/v3/pkg/generated/controllers/core"
+	"github.com/sirupsen/logrus"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -974,4 +977,87 @@ var _ = Describe("buildUpstreamClusterState", func() {
 		Expect(upstreamSpec.LogAnalyticsWorkspaceGroup).To(BeNil())
 		Expect(upstreamSpec.LogAnalyticsWorkspaceGroup).To(BeNil())
 	})
+})
+
+var _ = Describe("recordError", func() {
+    var (
+        aksConfig *aksv1.AKSClusterConfig
+        handler   *Handler
+    )
+
+    BeforeEach(func() {
+        aksConfig = &aksv1.AKSClusterConfig{
+            ObjectMeta: metav1.ObjectMeta{
+                Name:      "testrecorderror",
+                Namespace: "default",
+            },
+            Spec: aksv1.AKSClusterConfigSpec{
+                ResourceGroup: "test",
+                ClusterName:   "test",
+                NodePools: []aksv1.AKSNodePool{
+                    {
+                        Name:         to.Ptr("test"),
+                        Count:        to.Ptr(int32(1)),
+                        VMSize:       "Standard_DS2_v2",
+                        OsDiskSizeGB: to.Ptr(int32(1)),
+                    },
+                },
+            },
+        }
+
+        Expect(cl.Create(ctx, aksConfig)).To(Succeed())
+    })
+
+    It("should return same conflict error when onChange returns a conflict error", func() {
+        oldOutput := logrus.StandardLogger().Out
+        buf := bytes.Buffer{}
+        logrus.SetOutput(&buf)
+
+        aksConfigUpdated := aksConfig.DeepCopy()
+        Expect(cl.Update(ctx, aksConfigUpdated)).To(Succeed())
+
+        var expectedErr error
+        expectedConfig := &aksv1.AKSClusterConfig{}
+        onChange := func(key string, config *aksv1.AKSClusterConfig) (*aksv1.AKSClusterConfig, error) {
+            expectedErr = cl.Update(ctx, config)
+            return expectedConfig, expectedErr
+        }
+
+        aksConfig.ResourceVersion = "1"
+        handleFunction := handler.recordError(onChange)
+        config, err := handleFunction("", aksConfig)
+
+        Expect(config).To(Equal(expectedConfig))
+        Expect(err).To(Equal(expectedErr))
+        Expect("").To(Equal(string(buf.Bytes())))
+        logrus.SetOutput(oldOutput)
+    })
+
+    It("should return same conflict error when onChange returns a conflict error and print a debug log for the error", func() {
+        oldOutput := logrus.StandardLogger().Out
+        buf := bytes.Buffer{}
+        logrus.SetOutput(&buf)
+        logrus.SetLevel(logrus.DebugLevel)
+
+        aksConfigUpdated := aksConfig.DeepCopy()
+        Expect(cl.Update(ctx, aksConfigUpdated)).To(Succeed())
+
+        var expectedErr error
+        expectedConfig := &aksv1.AKSClusterConfig{}
+        onChange := func(key string, config *aksv1.AKSClusterConfig) (*aksv1.AKSClusterConfig, error) {
+            expectedErr = cl.Update(ctx, config)
+            return expectedConfig, expectedErr
+        }
+
+        aksConfig.ResourceVersion = "1"
+        handleFunction := handler.recordError(onChange)
+        config, err := handleFunction("", aksConfig)
+
+        Expect(config).To(Equal(expectedConfig))
+        Expect(err).To(MatchError(expectedErr))
+
+        cleanLogOutput := strings.Replace(string(buf.Bytes()), `\"`, `"`, -1)
+        Expect(strings.Contains(cleanLogOutput, err.Error())).To(BeTrue())
+        logrus.SetOutput(oldOutput)
+    })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

conflict errors occur since rancher also modifies aksconfig object. As conflict error returns empty object, errors like "Error recording akscc [] failure message: resource name may not be empty" occurs when we try to add a failure message to aksconfig status and update it.
The operation which results in conflict gets applied automatically in the next reconciliation call of the controller hence it is safe to just log it.

**Which issue(s) this PR fixes**
Issue  https://github.com/rancher/aks-operator/issues/665

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [x] squashed commits into logical changes
- [ ] includes documentation
- [x] adds unit tests
- [ ] adds or updates e2e tests
- [x] backport needed 
