### PR TITLE
Update and remove deprecated config in golangci lint

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,9 +14,8 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
       - name: Analysis
         uses: golangci/golangci-lint-action@v6
         with:
           args: -v
-          skip-pkg-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,15 +1,12 @@
 run:
   timeout: 5m
-  go: "1.20"
-  skip-files:
-    - "zz_generated_*"
-  skip-dirs:
-    - pkg/generated
+  go: "1.23"
   tests: false
   allow-parallel-runners: true
 
 output:
-  format: github-actions
+  formats:
+    - format: github-actions
 
 linters:
   disable-all: true
@@ -90,3 +87,7 @@ issues:
     - revive
     text: "var-naming: don't use an underscore in package name"
     path: 'mock(\w+)/doc.go$'
+  exclude-dirs:
+    - pkg/generated
+  exclude-files:
+    - "zz_generated_*"


### PR DESCRIPTION
### Updates
- `skip-pkg-cache` is removed in golangci lint.  [Reference](https://github.com/golangci/golangci-lint-action/tree/0bc16cda6e51961f4eb7c2ee2a92b0a4a5ddfd4b?tab=readme-ov-file#compatibility)
- `run.skip-dirs` is deprecated and is replaced by `issues.exclude-dirs` . [Reference](https://github.com/golangci/golangci-lint/pull/4509)

### Issue
- https://github.com/rancher/aks-operator/actions/runs/13379422004/job/37365219863?pr=858