### PR TITLE
[release-v2.10] update dependabot configuration to ignore lasso

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,27 @@ updates:
   commit-message:
     prefix: ":seedling:"
   target-branch: "main"
+# Go modules in release-v2.10 branch
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  ignore:
+    # Ignore controller-runtime as it's upgraded manually.
+    - dependency-name: "sigs.k8s.io/controller-runtime"
+    # Ignore k8s and its transitives modules as they are upgraded manually
+    # together with controller-runtime.
+    - dependency-name: "k8s.io/*"
+    # Ignore wrangler
+    - dependency-name: "github.com/rancher/wrangler"
+    - dependency-name: "github.com/rancher/wrangler/v3"
+    - dependency-name: "github.com/rancher/rancher/pkg/apis"
+    - dependency-name: "go.etcd.io/*"
+    - dependency-name: "github.com/Azure/azure-sdk-for-go"
+    - dependency-name: "github.com/rancher/lasso"
+  commit-message:
+    prefix: ":seedling:"
+  target-branch: "release-v2.10"
 # Go modules in release-v2.9 branch
 - package-ecosystem: "gomod"
   directory: "/"
@@ -45,6 +66,7 @@ updates:
     - dependency-name: "github.com/rancher/rancher/pkg/apis"
     - dependency-name: "go.etcd.io/*"
     - dependency-name: "github.com/Azure/azure-sdk-for-go"
+    - dependency-name: "github.com/rancher/lasso"
   commit-message:
     prefix: ":seedling:"
   target-branch: "release-v2.9"
@@ -65,6 +87,7 @@ updates:
     - dependency-name: "github.com/rancher/rancher/pkg/apis"
     - dependency-name: "go.etcd.io/*"
     - dependency-name: "github.com/Azure/azure-sdk-for-go"
+    - dependency-name: "github.com/rancher/lasso"
   commit-message:
     prefix: ":seedling:"
   target-branch: "release-v2.8"


### PR DESCRIPTION
Enhance the Dependabot configuration to include Go modules for the release-v2.10 branch and adjust ignored dependencies for better management of updates.