### PR TITLE
[release-v2.8] update dependabot configuration to ignore lasso

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,4 +18,25 @@ updates:
   # together with controller-runtime.
   - dependency-name: "k8s.io/*"
   - dependency-name: "go.etcd.io/*"
+# Go modules in release-v2.8 branch
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  ignore:
+    # Ignore controller-runtime as it's upgraded manually.
+    - dependency-name: "sigs.k8s.io/controller-runtime"
+    # Ignore k8s and its transitives modules as they are upgraded manually
+    # together with controller-runtime.
+    - dependency-name: "k8s.io/*"
+    # Ignore wrangler
+    - dependency-name: "github.com/rancher/wrangler"
+    - dependency-name: "github.com/rancher/wrangler/v3"
+    - dependency-name: "github.com/rancher/rancher/pkg/apis"
+    - dependency-name: "go.etcd.io/*"
+    - dependency-name: "github.com/Azure/azure-sdk-for-go"
+    - dependency-name: "github.com/rancher/lasso"
+  commit-message:
+    prefix: ":seedling:"
+  target-branch: "release-v2.8"
 


### PR DESCRIPTION
Enhance the Dependabot configuration to include the lasso package and adjust ignore rules for dependencies in the release-v2.8 branch.