### PR TITLE
[main] update dependabot configuration to ignore lasso

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,7 @@ updates:
     - dependency-name: "github.com/rancher/rancher/pkg/apis"
     - dependency-name: "go.etcd.io/*"
     - dependency-name: "github.com/Azure/azure-sdk-for-go"
+    - dependency-name: "github.com/rancher/lasso"
   commit-message:
     prefix: ":seedling:"
   target-branch: "release-v2.10"
@@ -85,6 +86,7 @@ updates:
     - dependency-name: "github.com/rancher/rancher/pkg/apis"
     - dependency-name: "go.etcd.io/*"
     - dependency-name: "github.com/Azure/azure-sdk-for-go"
+    - dependency-name: "github.com/rancher/lasso"
   commit-message:
     prefix: ":seedling:"
   target-branch: "release-v2.9"
@@ -105,6 +107,7 @@ updates:
     - dependency-name: "github.com/rancher/rancher/pkg/apis"
     - dependency-name: "go.etcd.io/*"
     - dependency-name: "github.com/Azure/azure-sdk-for-go"
+    - dependency-name: "github.com/rancher/lasso"
   commit-message:
     prefix: ":seedling:"
   target-branch: "release-v2.8"


### PR DESCRIPTION
Include the github.com/rancher/lasso dependency in the Dependabot updates for multiple release branches.