### PR TITLE
[main] Update workflow to delete old package versions from GHCR registry

### DIFF
--- a/.github/workflows/delete-old-versions.yaml
+++ b/.github/workflows/delete-old-versions.yaml
@@ -1,0 +1,38 @@
+name: Delete Old images and charts
+on:
+  schedule:
+    - cron: '0 1 * * 1' # Every Monday at 01:00 UTC
+  workflow_dispatch:
+
+jobs:
+  delete_old_packages:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete old aks-operator images
+        uses: actions/delete-package-versions@v4
+        with:
+          package-name: aks-operator
+          package-type: container
+          min-versions-to-keep: 30
+          token: ${{ secrets.GITHUB_TOKEN }}
+          owner: rancher
+
+      - name: Delete old rancher-aks-operator charts
+        uses: actions/delete-package-versions@v4
+        with:
+          package-name: rancher-aks-operator-chart/rancher-aks-operator
+          package-type: container
+          min-versions-to-keep: 7
+          token: ${{ secrets.GITHUB_TOKEN }}
+          owner: rancher
+
+      - name: Delete old rancher-aks-operator-crd charts
+        uses: actions/delete-package-versions@v4
+        with:
+          package-name: rancher-aks-operator-crd-chart/rancher-aks-operator-crd
+          package-type: container
+          min-versions-to-keep: 7
+          token: ${{ secrets.GITHUB_TOKEN }}
+          owner: rancher


### PR DESCRIPTION
Introduce a job that removes outdated package versions from the GitHub Container Registry, retaining a specified number of recent versions.

https://github.com/rancher/aks-operator/issues/818
