### PR TITLE
test: fix typo Succesfully -> Successfully

### DIFF
--- a/test/e2e/basic_cluster_test.go
+++ b/test/e2e/basic_cluster_test.go
@@ -34,7 +34,7 @@ var _ = Describe("BasicCluster", func() {
 
 	})
 
-	It("Succesfully creates a cluster", func() {
+	It("Successfully creates a cluster", func() {
 		By("Creating a cluster")
 		Expect(cl.Create(ctx, cluster)).Should(Succeed())
 


### PR DESCRIPTION
Minor typo fix in basic cluster test description.